### PR TITLE
Add ability to test whether warnings are raised during test steps

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -498,6 +498,11 @@ type TestStep struct {
 	// test to pass.
 	ExpectError *regexp.Regexp
 
+	// ExpectWarning allows the construction of test cases that we expect to pass
+	// with a warning. The specified regexp must match against stdout for the
+	// test to pass.
+	ExpectWarning *regexp.Regexp
+
 	// PlanOnly can be set to only run `plan` with this configuration, and not
 	// actually apply it. This is useful for ensuring config changes result in
 	// no-op plans

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -44,6 +44,25 @@ type WorkingDir struct {
 	reattachInfo tfexec.ReattachInfo
 }
 
+func (wd *WorkingDir) SetTFStdout() error {
+	dst, err := os.Create(filepath.Join(wd.baseDir, "stdout.txt"))
+	if err != nil {
+		return fmt.Errorf("unable to create file for writing stdout: %w", err)
+	}
+
+	wd.tf.SetStdout(dst)
+
+	return nil
+}
+
+func (wd *WorkingDir) UnsetTFStdout() {
+	wd.tf.SetStdout(nil)
+}
+
+func (wd *WorkingDir) GetBaseDir() string {
+	return wd.baseDir
+}
+
 // Close deletes the directories and files created to represent the receiving
 // working directory. After this method is called, the working directory object
 // is invalid and may no longer be used.
@@ -238,7 +257,14 @@ func (wd *WorkingDir) Apply(ctx context.Context) error {
 
 	logging.HelperResourceTrace(ctx, "Calling Terraform CLI apply command")
 
-	err := wd.tf.Apply(context.Background(), args...)
+	err := wd.SetTFStdout()
+	if err != nil {
+		return err
+	}
+
+	err = wd.tf.Apply(context.Background(), args...)
+
+	wd.UnsetTFStdout()
 
 	logging.HelperResourceTrace(ctx, "Called Terraform CLI apply command")
 


### PR DESCRIPTION
This is an exploratory PR examining usage of `-json` flag with `terraform-exec` apply command in order to obtain json stream that can be parsed to determine if expected diagnostic warning is being raised.

Testing locally required:

- manually altering `terraform exec` to add `-json` to `applyCmd`.
- modifying a test within the `random` provider to add `ExpectWarning` to a `TestStep`.
