### PR TITLE
ci: add `golangci` linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,25 @@
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - durationcheck
+    - errcheck
+    - exportloopref
+    # - forcetypeassert
+    - gofmt
+    - gosimple
+    - ineffassign
+    - makezero
+    - misspell
+    - nilerr
+    # - paralleltest
+    - predeclared
+    - staticcheck
+    - tenv
+    - unconvert
+    - unparam
+    - unused
+    - vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - durationcheck
     - errcheck
     - exportloopref
-    # - forcetypeassert
+    - forcetypeassert
     - gofmt
     - gosimple
     - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - makezero
     - misspell
     - nilerr
-    # - paralleltest
+    - paralleltest
     - predeclared
     - staticcheck
     - tenv

--- a/helper/acctest/random_test.go
+++ b/helper/acctest/random_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRandIntRange(t *testing.T) {
+	t.Parallel()
+
 	v := RandInt()
 	if vv := RandIntRange(v, v+1); vv != v {
 		t.Errorf("expected RandIntRange(%d, %d) to return %d, got %d", v, v+1, v, vv)
@@ -20,6 +22,8 @@ func TestRandIntRange(t *testing.T) {
 }
 
 func TestRandIpAddress(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		s           string
 		expected    *regexp.Regexp

--- a/helper/resource/id_test.go
+++ b/helper/resource/id_test.go
@@ -14,6 +14,8 @@ var allDigits = regexp.MustCompile(`^\d+$`)
 var allHex = regexp.MustCompile(`^[a-f0-9]+$`)
 
 func TestUniqueId(t *testing.T) {
+	t.Parallel()
+
 	split := func(rest string) (timestamp, increment string) {
 		return rest[:18], rest[18:]
 	}

--- a/helper/resource/plugin_test.go
+++ b/helper/resource/plugin_test.go
@@ -244,6 +244,8 @@ func TestSdkProviderFactoriesMerge(t *testing.T) {
 }
 
 func TestRunProviderCommand(t *testing.T) {
+	t.Parallel()
+
 	currentDir, err := os.Getwd()
 
 	if err != nil {

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -66,12 +66,14 @@ func shimOutputState(so *tfjson.StateOutput) (*terraform.OutputState, error) {
 		case string:
 			elements := make([]interface{}, len(v))
 			for i, el := range v {
+				//nolint:forcetypeassert // Guaranteed by type switch
 				elements[i] = el.(string)
 			}
 			os.Value = elements
 		case bool:
 			elements := make([]interface{}, len(v))
 			for i, el := range v {
+				//nolint:forcetypeassert // Guaranteed by type switch
 				elements[i] = el.(bool)
 			}
 			os.Value = elements
@@ -79,6 +81,7 @@ func shimOutputState(so *tfjson.StateOutput) (*terraform.OutputState, error) {
 		case json.Number:
 			elements := make([]interface{}, len(v))
 			for i, el := range v {
+				//nolint:forcetypeassert // Guaranteed by type switch
 				elements[i] = el.(json.Number)
 			}
 			os.Value = elements

--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -110,6 +110,7 @@ func TestWaitForState_inconsistent_positive(t *testing.T) {
 	}
 
 	if idx != 4 {
+		//nolint:forcetypeassert // Internal test
 		t.Fatalf("Expected index 4, given %d", idx.(int))
 	}
 }

--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -94,6 +94,8 @@ func UnknownPendingStateRefreshFunc() StateRefreshFunc {
 }
 
 func TestWaitForState_inconsistent_positive(t *testing.T) {
+	t.Parallel()
+
 	conf := &StateChangeConf{
 		Pending:                   []string{"replicating"},
 		Target:                    []string{"done"},
@@ -116,6 +118,8 @@ func TestWaitForState_inconsistent_positive(t *testing.T) {
 }
 
 func TestWaitForState_inconsistent_negative(t *testing.T) {
+	t.Parallel()
+
 	refreshCount := int64(0)
 	f := InconsistentStateRefreshFunc()
 	refresh := func() (interface{}, string, error) {
@@ -152,6 +156,8 @@ func TestWaitForState_inconsistent_negative(t *testing.T) {
 }
 
 func TestWaitForState_timeout(t *testing.T) {
+	t.Parallel()
+
 	old := refreshGracePeriod
 	refreshGracePeriod = 5 * time.Millisecond
 	defer func() {
@@ -184,6 +190,8 @@ func TestWaitForState_timeout(t *testing.T) {
 // Make sure a timeout actually cancels the refresh goroutine and waits for its
 // return.
 func TestWaitForState_cancel(t *testing.T) {
+	t.Parallel()
+
 	// make this refresh func block until we cancel it
 	cancel := make(chan struct{})
 	refresh := func() (interface{}, string, error) {
@@ -239,6 +247,8 @@ func TestWaitForState_cancel(t *testing.T) {
 }
 
 func TestWaitForState_success(t *testing.T) {
+	t.Parallel()
+
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
 		Target:  []string{"running"},
@@ -256,6 +266,8 @@ func TestWaitForState_success(t *testing.T) {
 }
 
 func TestWaitForState_successUnknownPending(t *testing.T) {
+	t.Parallel()
+
 	conf := &StateChangeConf{
 		Target:  []string{"done"},
 		Refresh: UnknownPendingStateRefreshFunc(),
@@ -272,6 +284,8 @@ func TestWaitForState_successUnknownPending(t *testing.T) {
 }
 
 func TestWaitForState_successEmpty(t *testing.T) {
+	t.Parallel()
+
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
 		Target:  []string{},
@@ -291,6 +305,8 @@ func TestWaitForState_successEmpty(t *testing.T) {
 }
 
 func TestWaitForState_failureEmpty(t *testing.T) {
+	t.Parallel()
+
 	conf := &StateChangeConf{
 		Pending:        []string{"pending", "incomplete"},
 		Target:         []string{},
@@ -313,6 +329,8 @@ func TestWaitForState_failureEmpty(t *testing.T) {
 }
 
 func TestWaitForState_failure(t *testing.T) {
+	t.Parallel()
+
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
 		Target:  []string{"running"},
@@ -334,6 +352,8 @@ func TestWaitForState_failure(t *testing.T) {
 }
 
 func TestWaitForStateContext_cancel(t *testing.T) {
+	t.Parallel()
+
 	// make this refresh func block until we cancel it
 	ctx, cancel := context.WithCancel(context.Background())
 	refresh := func() (interface{}, string, error) {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1457,7 +1457,12 @@ func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		if !r.MatchString(rs.Value.(string)) {
+		valStr, ok := rs.Value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for resource value", rs.Value)
+		}
+
+		if !r.MatchString(valStr) {
 			return fmt.Errorf(
 				"Output '%s': %#v didn't match %q",
 				name,

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -31,7 +31,7 @@ import (
 )
 
 // flagSweep is a flag available when running tests on the command line. It
-// contains a comma seperated list of regions to for the sweeper functions to
+// contains a comma separated list of regions to for the sweeper functions to
 // run in.  This flag bypasses the normal Test path and instead runs functions designed to
 // clean up any leaked resources a testing environment could have created. It is
 // a best effort attempt, and relies on Provider authors to implement "Sweeper"
@@ -52,7 +52,7 @@ import (
 
 var flagSweep = flag.String("sweep", "", "List of Regions to run available Sweepers")
 var flagSweepAllowFailures = flag.Bool("sweep-allow-failures", false, "Enable to allow Sweeper Tests to continue after failures")
-var flagSweepRun = flag.String("sweep-run", "", "Comma seperated list of Sweeper Tests to run")
+var flagSweepRun = flag.String("sweep-run", "", "Comma separated list of Sweeper Tests to run")
 var sweeperFuncs map[string]*Sweeper
 
 // SweeperFunc is a signature for a function that acts as a sweeper. It
@@ -186,7 +186,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 	return sweeperRunList, nil
 }
 
-// filterSweepers takes a comma seperated string listing the names of sweepers
+// filterSweepers takes a comma separated string listing the names of sweepers
 // to be ran, and returns a filtered set from the list of all of sweepers to
 // run based on the names given.
 func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
@@ -233,7 +233,7 @@ func filterSweeperWithDependencies(name string, source map[string]*Sweeper) map[
 	return result
 }
 
-// runSweeperWithRegion recieves a sweeper and a region, and recursively calls
+// runSweeperWithRegion receives a sweeper and a region, and recursively calls
 // itself with that region for every dependency found for that sweeper. If there
 // are no dependencies, invoke the contained sweeper fun with the region, and
 // add the success/fail status to the sweeperRunList.

--- a/helper/resource/testing_new_test.go
+++ b/helper/resource/testing_new_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestShimState(t *testing.T) {
+	t.Parallel()
+
 	type expectedError struct {
 		Prefix string
 	}
@@ -1087,7 +1089,11 @@ func TestShimState(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
+		i, tc := i, tc
+
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			t.Parallel()
+
 			var rawState tfjson.State
 			rawState.UseJSONNumber(true)
 

--- a/helper/resource/testing_sets_test.go
+++ b/helper/resource/testing_sets_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestTestCheckTypeSetElemAttr(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Description       string
 		ResourceAddress   string
@@ -400,7 +402,11 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Description, func(t *testing.T) {
+			t.Parallel()
+
 			err := TestCheckTypeSetElemAttr(testCase.ResourceAddress, testCase.ResourceAttribute, testCase.Value)(testCase.TerraformState)
 
 			if err != nil {
@@ -424,6 +430,8 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 }
 
 func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Description             string
 		FirstResourceAddress    string
@@ -1002,7 +1010,11 @@ func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Description, func(t *testing.T) {
+			t.Parallel()
+
 			err := TestCheckTypeSetElemAttrPair(
 				testCase.FirstResourceAddress,
 				testCase.FirstResourceAttribute,
@@ -1030,6 +1042,8 @@ func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
 }
 
 func TestTestMatchTypeSetElemNestedAttrs(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Description       string
 		ResourceAddress   string
@@ -1740,7 +1754,11 @@ func TestTestMatchTypeSetElemNestedAttrs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Description, func(t *testing.T) {
+			t.Parallel()
+
 			err := TestMatchTypeSetElemNestedAttrs(testCase.ResourceAddress, testCase.ResourceAttribute, testCase.Values)(testCase.TerraformState)
 
 			if err != nil {
@@ -1764,6 +1782,8 @@ func TestTestMatchTypeSetElemNestedAttrs(t *testing.T) {
 }
 
 func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Description       string
 		ResourceAddress   string
@@ -2573,7 +2593,11 @@ func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Description, func(t *testing.T) {
+			t.Parallel()
+
 			err := TestCheckTypeSetElemNestedAttrs(testCase.ResourceAddress, testCase.ResourceAttribute, testCase.Values)(testCase.TerraformState)
 
 			if err != nil {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -103,7 +103,10 @@ func TestComposeAggregateTestCheckFunc(t *testing.T) {
 		t.Fatalf("Expected errors")
 	}
 
-	multi := err.(*multierror.Error)
+	multi, ok := err.(*multierror.Error)
+	if !ok {
+		t.Fatalf("unexpected type %T for err", err)
+	}
 	if !strings.Contains(multi.Errors[0].Error(), "Error 1") {
 		t.Fatalf("Expected Error 1, Got %s", multi.Errors[0])
 	}

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -67,6 +67,8 @@ func testExpectTFatal(t *testing.T, testLogic func()) {
 }
 
 func TestParallelTest(t *testing.T) {
+	t.Parallel()
+
 	mt := new(mockT)
 
 	ParallelTest(mt, TestCase{
@@ -89,6 +91,8 @@ func TestParallelTest(t *testing.T) {
 }
 
 func TestComposeAggregateTestCheckFunc(t *testing.T) {
+	t.Parallel()
+
 	check1 := func(s *terraform.State) error {
 		return errors.New("Error 1")
 	}
@@ -116,6 +120,8 @@ func TestComposeAggregateTestCheckFunc(t *testing.T) {
 }
 
 func TestComposeTestCheckFunc(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		F      []TestCheckFunc
 		Result string
@@ -184,6 +190,8 @@ func (t *mockT) Name() string {
 }
 
 func TestTest_Main(t *testing.T) {
+	t.Parallel()
+
 	flag.Parse()
 	if *flagSweep == "" {
 		// Tests for the TestMain method used for Sweepers will panic without the -sweep
@@ -212,8 +220,10 @@ func TestTest_Main(t *testing.T) {
 	for _, tc := range cases {
 		// reset sweepers
 		sweeperFuncs = map[string]*Sweeper{}
-
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			for n, s := range tc.Sweepers {
 				AddTestSweepers(n, s)
 			}
@@ -226,6 +236,8 @@ func TestTest_Main(t *testing.T) {
 }
 
 func TestFilterSweepers(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name             string
 		Sweepers         map[string]*Sweeper
@@ -420,8 +432,11 @@ func TestFilterSweepers(t *testing.T) {
 	for _, tc := range cases {
 		// reset sweepers
 		sweeperFuncs = map[string]*Sweeper{}
+		tc := tc
 
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			actualSweepers := filterSweepers(tc.Filter, tc.Sweepers)
 
 			var keys []string
@@ -439,6 +454,8 @@ func TestFilterSweepers(t *testing.T) {
 }
 
 func TestFilterSweeperWithDependencies(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name             string
 		Sweepers         map[string]*Sweeper
@@ -660,8 +677,11 @@ func TestFilterSweeperWithDependencies(t *testing.T) {
 	for _, tc := range cases {
 		// reset sweepers
 		sweeperFuncs = map[string]*Sweeper{}
+		tc := tc
 
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			actualSweepers := filterSweeperWithDependencies(tc.StartingSweeper, tc.Sweepers)
 
 			var keys []string
@@ -679,6 +699,8 @@ func TestFilterSweeperWithDependencies(t *testing.T) {
 }
 
 func TestRunSweepers(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name            string
 		Sweepers        map[string]*Sweeper
@@ -834,8 +856,11 @@ func TestRunSweepers(t *testing.T) {
 	for _, tc := range cases {
 		// reset sweepers
 		sweeperFuncs = map[string]*Sweeper{}
+		tc := tc
 
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			sweeperRunList, err := runSweepers([]string{"test"}, tc.Sweepers, tc.AllowFailures)
 			fmt.Printf("sweeperRunList: %#v\n", sweeperRunList)
 
@@ -2094,6 +2119,8 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 }
 
 func TestTestCheckResourceAttrPair(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		nameFirst  string
 		keyFirst   string
@@ -2362,7 +2389,11 @@ func TestTestCheckResourceAttrPair(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			fn := TestCheckResourceAttrPair(test.nameFirst, test.keyFirst, test.nameSecond, test.keySecond)
 			err := fn(test.state)
 

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -1782,6 +1782,7 @@ func TestTest_TestStep_ProviderFactories_Import_External_WithPersistMatch(t *tes
 	})
 }
 
+//nolint:paralleltest // Can't use t.Parallel with t.Setenv
 func TestTest_TestStep_ProviderFactories_Import_External_WithPersistMatch_WithPersistWorkingDir(t *testing.T) {
 	var result1, result2 string
 
@@ -1891,6 +1892,7 @@ func TestTest_TestStep_ProviderFactories_Import_External_WithoutPersistNonMatch(
 	})
 }
 
+//nolint:paralleltest // Can't use t.Parallel with t.Setenv
 func TestTest_TestStep_ProviderFactories_Import_External_WithoutPersistNonMatch_WithPersistWorkingDir(t *testing.T) {
 	var result1, result2 string
 
@@ -2028,6 +2030,7 @@ func TestTest_TestStep_ProviderFactories_Refresh_Inline(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // Can't use t.Parallel with t.Setenv
 func TestTest_TestStep_ProviderFactories_CopyWorkingDir_EachTestStep(t *testing.T) {
 	t.Setenv(plugintest.EnvTfAccPersistWorkingDir, "1")
 	workingDir := t.TempDir()

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -2369,6 +2369,7 @@ func composeImportStateCheck(fs ...ImportStateCheckFunc) ImportStateCheckFunc {
 	}
 }
 
+//nolint:unparam // Generic test function
 func testExtractResourceAttrInstanceState(id, attributeName string, attributeValue *string) ImportStateCheckFunc {
 	return func(is []*terraform.InstanceState) error {
 		for _, v := range is {
@@ -2407,6 +2408,7 @@ func testCheckResourceAttrInstanceState(id *string, attributeName, attributeValu
 	}
 }
 
+//nolint:unparam // Generic test function
 func testExtractResourceAttr(resourceName string, attributeName string, attributeValue *string) TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -2095,7 +2095,11 @@ func TestTest_TestStep_ProviderFactories_RefreshWithPlanModifier_Inline(t *testi
 						"random_password": {
 							CustomizeDiff: customdiff.All(
 								func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-									special := d.Get("special").(bool)
+									special, ok := d.Get("special").(bool)
+									if !ok {
+										return fmt.Errorf("unexpected type %T for 'special' key", d.Get("special"))
+									}
+
 									if special == true {
 										err := d.SetNew("special", false)
 										if err != nil {
@@ -2175,7 +2179,10 @@ func TestTest_TestStep_ProviderFactories_Import_Inline_With_Data_Source(t *testi
 					DataSourcesMap: map[string]*schema.Resource{
 						"http": {
 							ReadContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) (diags diag.Diagnostics) {
-								url := d.Get("url").(string)
+								url, ok := d.Get("url").(string)
+								if !ok {
+									return diag.Errorf("unexpected type %T for 'url' key", d.Get("url"))
+								}
 
 								responseHeaders := map[string]string{
 									"headerOne":   "one",

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -58,6 +58,8 @@ func TestRetry_timeout(t *testing.T) {
 }
 
 func TestRetry_hang(t *testing.T) {
+	t.Parallel()
+
 	old := refreshGracePeriod
 	refreshGracePeriod = 50 * time.Millisecond
 	defer func() {

--- a/internal/addrs/instance_key.go
+++ b/internal/addrs/instance_key.go
@@ -20,7 +20,7 @@ type instanceKey interface {
 	String() string
 }
 
-// NoKey represents the absense of an instanceKey, for the single instance
+// NoKey represents the absence of an instanceKey, for the single instance
 // of a configuration object that does not use "count" or "for_each" at all.
 var NoKey instanceKey
 

--- a/internal/configs/configschema/coerce_value_test.go
+++ b/internal/configs/configschema/coerce_value_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCoerceValue(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		Schema    *Block
 		Input     cty.Value
@@ -544,7 +546,11 @@ func TestCoerceValue(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			gotValue, gotErrObj := test.Schema.CoerceValue(test.Input)
 
 			if gotErrObj == nil {

--- a/internal/configs/configschema/empty_value.go
+++ b/internal/configs/configschema/empty_value.go
@@ -7,12 +7,12 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 )
 
-// EmptyValue returns the "empty value" for the recieving block, which for
+// EmptyValue returns the "empty value" for the receiving block, which for
 // a block type is a non-null object where all of the attribute values are
 // the empty values of the block's attributes and nested block types.
 //
 // In other words, it returns the value that would be returned if an empty
-// block were decoded against the recieving schema, assuming that no required
+// block were decoded against the receiving schema, assuming that no required
 // attribute or block constraints were honored.
 func (b *Block) EmptyValue() cty.Value {
 	vals := make(map[string]cty.Value)

--- a/internal/configs/configschema/empty_value_test.go
+++ b/internal/configs/configschema/empty_value_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestBlockEmptyValue(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Schema *Block
 		Want   cty.Value
@@ -161,7 +163,11 @@ func TestBlockEmptyValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%#v", test.Schema), func(t *testing.T) {
+			t.Parallel()
+
 			got := test.Schema.EmptyValue()
 			if !test.Want.RawEquals(got) {
 				t.Errorf("wrong result\nschema: %#v\ngot: %#v\nwant: %#v", test.Schema, got, test.Want)

--- a/internal/configs/configschema/implied_type_test.go
+++ b/internal/configs/configschema/implied_type_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestBlockImpliedType(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		Schema *Block
 		Want   cty.Type
@@ -117,7 +119,11 @@ func TestBlockImpliedType(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.Schema.ImpliedType()
 			if !got.Equals(test.Want) {
 				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)

--- a/internal/configs/configschema/schema.go
+++ b/internal/configs/configschema/schema.go
@@ -125,7 +125,7 @@ const (
 	NestingSingle
 
 	// NestingGroup is similar to NestingSingle in that it calls for only a
-	// single instance of a given block type with no labels, but it additonally
+	// single instance of a given block type with no labels, but it additionally
 	// guarantees that its result will never be null, even if the block is
 	// absent, and instead the nested attributes and blocks will be treated
 	// as absent in that case. (Any required attributes or blocks within the

--- a/internal/configs/hcl2shim/flatmap_test.go
+++ b/internal/configs/hcl2shim/flatmap_test.go
@@ -331,6 +331,8 @@ func TestFlatmapValueFromHCL2FromFlatmap(t *testing.T) {
 	}
 }
 func TestHCL2ValueFromFlatmap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Flatmap map[string]string
 		Type    cty.Type
@@ -738,7 +740,11 @@ func TestHCL2ValueFromFlatmap(t *testing.T) {
 	}
 
 	for i, test := range tests {
+		i, test := i, test
+
 		t.Run(fmt.Sprintf("%d %#v as %#v", i, test.Flatmap, test.Type), func(t *testing.T) {
+			t.Parallel()
+
 			got, err := HCL2ValueFromFlatmap(test.Flatmap, test.Type)
 
 			if test.WantErr != "" {

--- a/internal/configs/hcl2shim/paths_test.go
+++ b/internal/configs/hcl2shim/paths_test.go
@@ -21,6 +21,8 @@ var (
 )
 
 func TestPathFromFlatmap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Flatmap string
 		Type    cty.Type
@@ -209,7 +211,11 @@ func TestPathFromFlatmap(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%s as %#v", test.Flatmap, test.Type), func(t *testing.T) {
+			t.Parallel()
+
 			got, err := requiresReplacePath(test.Flatmap, test.Type)
 
 			if test.WantErr != "" {
@@ -234,6 +240,8 @@ func TestPathFromFlatmap(t *testing.T) {
 }
 
 func TestRequiresReplace(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		attrs    []string
@@ -356,7 +364,11 @@ func TestRequiresReplace(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			rp, err := RequiresReplace(tc.attrs, tc.ty)
 			if err != nil {
 				t.Fatal(err)
@@ -370,6 +382,8 @@ func TestRequiresReplace(t *testing.T) {
 }
 
 func TestFlatmapKeyFromPath(t *testing.T) {
+	t.Parallel()
+
 	for i, tc := range []struct {
 		path cty.Path
 		attr string
@@ -399,7 +413,11 @@ func TestFlatmapKeyFromPath(t *testing.T) {
 			attr: "attr.key.obj_attr.0.force_new",
 		},
 	} {
+		i, tc := i, tc
+
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			attr := FlatmapKeyFromPath(tc.path)
 			if attr != tc.attr {
 				t.Fatalf("expected:%q got:%q", tc.attr, attr)

--- a/internal/configs/hcl2shim/values_equiv_test.go
+++ b/internal/configs/hcl2shim/values_equiv_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestValuesSDKEquivalent(t *testing.T) {
+	t.Parallel()
+
 	piBig, _, err := big.ParseFloat("3.14159265358979323846264338327950288419716939937510582097494459", 10, 512, big.ToZero)
 	if err != nil {
 		t.Fatal(err)
@@ -417,7 +419,11 @@ func TestValuesSDKEquivalent(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%#v ≈ %#v", test.A, test.B), func(t *testing.T) {
+			t.Parallel()
+
 			run(t, test.A, test.B, test.Want)
 		})
 		// This function is symmetrical, so we'll also test in reverse so

--- a/internal/configs/hcl2shim/values_test.go
+++ b/internal/configs/hcl2shim/values_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestConfigValueFromHCL2Block(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Input  cty.Value
 		Schema *configschema.Block
@@ -239,7 +241,11 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%#v", test.Input), func(t *testing.T) {
+			t.Parallel()
+
 			got := ConfigValueFromHCL2Block(test.Input, test.Schema)
 			if !reflect.DeepEqual(got, test.Want) {
 				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)
@@ -249,6 +255,8 @@ func TestConfigValueFromHCL2Block(t *testing.T) {
 }
 
 func TestConfigValueFromHCL2(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Input cty.Value
 		Want  interface{}
@@ -326,7 +334,11 @@ func TestConfigValueFromHCL2(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%#v", test.Input), func(t *testing.T) {
+			t.Parallel()
+
 			got := ConfigValueFromHCL2(test.Input)
 			if !reflect.DeepEqual(got, test.Want) {
 				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)
@@ -336,6 +348,8 @@ func TestConfigValueFromHCL2(t *testing.T) {
 }
 
 func TestHCL2ValueFromConfigValue(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Input interface{}
 		Want  cty.Value
@@ -409,7 +423,11 @@ func TestHCL2ValueFromConfigValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%#v", test.Input), func(t *testing.T) {
+			t.Parallel()
+
 			got := HCL2ValueFromConfigValue(test.Input)
 			if !got.RawEquals(test.Want) {
 				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)

--- a/internal/plugintest/util_test.go
+++ b/internal/plugintest/util_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCopyFile(t *testing.T) {
+	t.Parallel()
+
 	srcDir := t.TempDir()
 
 	_, err := os.Create(filepath.Join(srcDir, "src.txt"))
@@ -39,6 +41,8 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestCopyDir(t *testing.T) {
+	t.Parallel()
+
 	srcDir := t.TempDir()
 
 	_, err := os.Create(filepath.Join(srcDir, "src.txt"))

--- a/internal/plugintest/working_dir_json_test.go
+++ b/internal/plugintest/working_dir_json_test.go
@@ -17,6 +17,8 @@ import (
 // This test also proves that when changing the HCL and JSON formats back and
 // forth, the framework deletes the previous configuration file.
 func TestJSONConfig(t *testing.T) {
+	t.Parallel()
+
 	providerFactories := map[string]func() (*schema.Provider, error){
 		"tst": func() (*schema.Provider, error) { return tstProvider(), nil }, //nolint:unparam // required signature
 	}

--- a/internal/plugintest/working_dir_json_test.go
+++ b/internal/plugintest/working_dir_json_test.go
@@ -56,7 +56,11 @@ func tstProvider() *schema.Provider {
 }
 
 func resourceTstTCreate(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	d.SetId(d.Get("s").(string))
+	strVal, ok := d.Get("s").(string)
+	if !ok {
+		return diag.Errorf("unexpected type %T for 's' key", d.Get("s"))
+	}
+	d.SetId(strVal)
 	return nil
 }
 

--- a/internal/tfdiags/contextual_test.go
+++ b/internal/tfdiags/contextual_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGetAttribute(t *testing.T) {
+	t.Parallel()
+
 	path := cty.Path{
 		cty.GetAttrStep{Name: "foo"},
 		cty.IndexStep{Key: cty.NumberIntVal(0)},

--- a/internal/tfdiags/diagnostics_test.go
+++ b/internal/tfdiags/diagnostics_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 func TestDiagnosticsErr(t *testing.T) {
+	t.Parallel()
+
 	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		err := diags.Err()
 		if err != nil {
@@ -18,6 +22,8 @@ func TestDiagnosticsErr(t *testing.T) {
 		}
 	})
 	t.Run("warning only", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, SimpleWarning("bad"))
 		err := diags.Err()
@@ -26,6 +32,8 @@ func TestDiagnosticsErr(t *testing.T) {
 		}
 	})
 	t.Run("one error", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		err := diags.Err()
@@ -37,6 +45,8 @@ func TestDiagnosticsErr(t *testing.T) {
 		}
 	})
 	t.Run("two errors", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		diags = append(diags, FromError(errors.New("didn't work either")))
@@ -55,6 +65,8 @@ func TestDiagnosticsErr(t *testing.T) {
 		}
 	})
 	t.Run("error and warning", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		diags = append(diags, SimpleWarning("didn't work either"))
@@ -80,7 +92,11 @@ func TestDiagnosticsErr(t *testing.T) {
 }
 
 func TestDiagnosticsErrWithWarnings(t *testing.T) {
+	t.Parallel()
+
 	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		err := diags.ErrWithWarnings()
 		if err != nil {
@@ -88,6 +104,8 @@ func TestDiagnosticsErrWithWarnings(t *testing.T) {
 		}
 	})
 	t.Run("warning only", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, SimpleWarning("bad"))
 		err := diags.ErrWithWarnings()
@@ -100,6 +118,8 @@ func TestDiagnosticsErrWithWarnings(t *testing.T) {
 		}
 	})
 	t.Run("one error", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		err := diags.ErrWithWarnings()
@@ -111,6 +131,8 @@ func TestDiagnosticsErrWithWarnings(t *testing.T) {
 		}
 	})
 	t.Run("two errors", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		diags = append(diags, FromError(errors.New("didn't work either")))
@@ -129,6 +151,8 @@ func TestDiagnosticsErrWithWarnings(t *testing.T) {
 		}
 	})
 	t.Run("error and warning", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		diags = append(diags, SimpleWarning("didn't work either"))
@@ -154,7 +178,11 @@ func TestDiagnosticsErrWithWarnings(t *testing.T) {
 }
 
 func TestDiagnosticsNonFatalErr(t *testing.T) {
+	t.Parallel()
+
 	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		err := diags.NonFatalErr()
 		if err != nil {
@@ -162,6 +190,8 @@ func TestDiagnosticsNonFatalErr(t *testing.T) {
 		}
 	})
 	t.Run("warning only", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, SimpleWarning("bad"))
 		err := diags.NonFatalErr()
@@ -174,6 +204,8 @@ func TestDiagnosticsNonFatalErr(t *testing.T) {
 		}
 	})
 	t.Run("one error", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		err := diags.NonFatalErr()
@@ -188,6 +220,8 @@ func TestDiagnosticsNonFatalErr(t *testing.T) {
 		}
 	})
 	t.Run("two errors", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		diags = append(diags, FromError(errors.New("didn't work either")))
@@ -209,6 +243,8 @@ func TestDiagnosticsNonFatalErr(t *testing.T) {
 		}
 	})
 	t.Run("error and warning", func(t *testing.T) {
+		t.Parallel()
+
 		var diags Diagnostics
 		diags = append(diags, FromError(errors.New("didn't work")))
 		diags = append(diags, SimpleWarning("didn't work either"))

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -892,7 +892,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 				continue
 			}
 
-			// If the last diff was a computed value then the absense of
+			// If the last diff was a computed value then the absence of
 			// that value is allowed since it may mean the value ended up
 			// being the same.
 			if diffOld.NewComputed {

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestInstanceDiff_ChangeType(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		diff   *InstanceDiff
 		Result diffChangeType
@@ -82,6 +84,8 @@ func TestInstanceDiff_ChangeType(t *testing.T) {
 }
 
 func TestInstanceDiff_Empty(t *testing.T) {
+	t.Parallel()
+
 	var rd *InstanceDiff
 
 	if !rd.Empty() {
@@ -114,6 +118,8 @@ func TestInstanceDiff_Empty(t *testing.T) {
 }
 
 func TestInstanceDiff_RequiresNew(t *testing.T) {
+	t.Parallel()
+
 	rd := &InstanceDiff{
 		Attributes: map[string]*ResourceAttrDiff{
 			"foo": {},
@@ -132,6 +138,8 @@ func TestInstanceDiff_RequiresNew(t *testing.T) {
 }
 
 func TestInstanceDiff_RequiresNew_nil(t *testing.T) {
+	t.Parallel()
+
 	var rd *InstanceDiff
 
 	if rd.RequiresNew() {
@@ -140,6 +148,8 @@ func TestInstanceDiff_RequiresNew_nil(t *testing.T) {
 }
 
 func TestInstanceDiffSame(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		One, Two *InstanceDiff
 		Same     bool
@@ -810,7 +820,11 @@ func TestInstanceDiffSame(t *testing.T) {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc
+
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			same, reason := tc.One.Same(tc.Two)
 			if same != tc.Same {
 				t.Fatalf("%d: expected same: %t, got %t (%s)\n\n one: %#v\n\ntwo: %#v",
@@ -825,6 +839,8 @@ func TestInstanceDiffSame(t *testing.T) {
 }
 
 func TestCountFlatmapContainerValues(t *testing.T) {
+	t.Parallel()
+
 	for i, tc := range []struct {
 		attrs map[string]string
 		key   string
@@ -851,7 +867,11 @@ func TestCountFlatmapContainerValues(t *testing.T) {
 			count: "2",
 		},
 	} {
+		i, tc := i, tc
+
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
 			count := countFlatmapContainerValues(tc.key, tc.attrs)
 			if count != tc.count {
 				t.Fatalf("expected %q, got %q", tc.count, count)

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -58,6 +58,7 @@ func NewResourceConfigRaw(raw map[string]interface{}) *ResourceConfig {
 	// something is relying on the fact that in the old world the raw and
 	// config maps were always distinct, and thus you could in principle mutate
 	// one without affecting the other. (I sure hope nobody was doing that, though!)
+	//nolint:forcetypeassert
 	cfg := hcl2shim.ConfigValueFromHCL2(v).(map[string]interface{})
 
 	return &ResourceConfig{
@@ -163,7 +164,10 @@ func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 	}
 
 	// Force the type
-	result := copiedConfig.(*ResourceConfig)
+	result, ok := copiedConfig.(*ResourceConfig)
+	if !ok {
+		panic(fmt.Errorf("unexpected type %T for copiedConfig", copiedConfig))
+	}
 
 	return result
 }

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestParseResourceAddress(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		Input    string
 		Expected *resourceAddress
@@ -187,7 +189,11 @@ func TestParseResourceAddress(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
+		tn, tc := tn, tc
+
 		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
 			out, err := parseResourceAddress(tc.Input)
 			if (err != nil) != tc.Err {
 				t.Fatalf("%s: unexpected err: %#v", tn, err)
@@ -212,6 +218,8 @@ func TestParseResourceAddress(t *testing.T) {
 }
 
 func TestResourceAddressLess(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		A    string
 		B    string
@@ -280,7 +288,11 @@ func TestResourceAddressLess(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(fmt.Sprintf("%s < %s", test.A, test.B), func(t *testing.T) {
+			t.Parallel()
+
 			addrA, err := parseResourceAddress(test.A)
 			if err != nil {
 				t.Fatal(err)

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestResourceConfigGet(t *testing.T) {
+	t.Parallel()
+
 	fooStringSchema := &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"foo": {Type: cty.String, Optional: true},
@@ -184,10 +186,14 @@ func TestResourceConfigGet(t *testing.T) {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc
+
 		rc := NewResourceConfigShimmed(tc.Config, tc.Schema)
 
 		// Test getting a key
 		t.Run(fmt.Sprintf("get-%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			v, ok := rc.Get(tc.Key)
 			if ok && v == nil {
 				t.Fatal("(nil, true) returned from Get")
@@ -200,6 +206,8 @@ func TestResourceConfigGet(t *testing.T) {
 
 		// Test copying and equality
 		t.Run(fmt.Sprintf("copy-and-equal-%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			copiedConfig := rc.DeepCopy()
 			if !reflect.DeepEqual(copiedConfig, rc) {
 				t.Fatalf("bad:\n\n%#v\n\n%#v", copiedConfig, rc)
@@ -216,6 +224,8 @@ func TestResourceConfigGet(t *testing.T) {
 }
 
 func TestResourceConfigDeepCopy_nil(t *testing.T) {
+	t.Parallel()
+
 	var nilRc *ResourceConfig
 	actual := nilRc.DeepCopy()
 	if actual != nil {
@@ -224,6 +234,8 @@ func TestResourceConfigDeepCopy_nil(t *testing.T) {
 }
 
 func TestResourceConfigDeepCopy_nilComputed(t *testing.T) {
+	t.Parallel()
+
 	rc := &ResourceConfig{}
 	actual := rc.DeepCopy()
 	if actual.ComputedKeys != nil {
@@ -232,6 +244,8 @@ func TestResourceConfigDeepCopy_nilComputed(t *testing.T) {
 }
 
 func TestResourceConfigEqual_nil(t *testing.T) {
+	t.Parallel()
+
 	var nilRc *ResourceConfig
 	notNil := NewResourceConfigShimmed(cty.EmptyObjectVal, &configschema.Block{})
 
@@ -245,6 +259,8 @@ func TestResourceConfigEqual_nil(t *testing.T) {
 }
 
 func TestResourceConfigEqual_computedKeyOrder(t *testing.T) {
+	t.Parallel()
+
 	v := cty.ObjectVal(map[string]cty.Value{
 		"foo": cty.UnknownVal(cty.String),
 	})
@@ -266,6 +282,8 @@ func TestResourceConfigEqual_computedKeyOrder(t *testing.T) {
 }
 
 func TestUnknownCheckWalker(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name   string
 		Input  interface{}
@@ -300,7 +318,11 @@ func TestUnknownCheckWalker(t *testing.T) {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc
+
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			t.Parallel()
+
 			var w unknownCheckWalker
 			if err := reflectwalk.Walk(tc.Input, &w); err != nil {
 				t.Fatalf("err: %s", err)
@@ -314,6 +336,8 @@ func TestUnknownCheckWalker(t *testing.T) {
 }
 
 func TestNewResourceConfigShimmed(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Name     string
 		Val      cty.Value
@@ -667,7 +691,11 @@ func TestNewResourceConfigShimmed(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(*testing.T) {
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := NewResourceConfigShimmed(tc.Val, tc.Schema)
 			if !tc.Expected.Equal(cfg) {
 				t.Fatalf("expected:\n%#v\ngot:\n%#v", tc.Expected, cfg)

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -373,6 +373,7 @@ func (s *State) Remove(addr ...string) error {
 		case *ResourceState:
 			s.removeResource(path, v)
 		case *InstanceState:
+			//nolint:forcetypeassert
 			s.removeInstance(r.Parent.Value.(*ResourceState), v)
 		default:
 			return fmt.Errorf("unknown type to delete: %T", r.Value)
@@ -556,7 +557,12 @@ func (s *State) DeepCopy() *State {
 		panic(err)
 	}
 
-	return copiedState.(*State)
+	state, ok := copiedState.(*State)
+	if !ok {
+		panic(fmt.Errorf("unexpected type %T for copiedState", state))
+	}
+
+	return state
 }
 
 func (s *State) Init() {
@@ -1399,7 +1405,12 @@ func (s *InstanceState) DeepCopy() *InstanceState {
 		panic(err)
 	}
 
-	return copiedState.(*InstanceState)
+	instanceState, ok := copiedState.(*InstanceState)
+	if !ok {
+		panic(fmt.Errorf("unexpected type %T for copiedState", copiedState))
+	}
+
+	return instanceState
 }
 
 func (s *InstanceState) Empty() bool {

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestStateValidate(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		In  *State
 		Err bool
@@ -52,6 +54,8 @@ func TestStateValidate(t *testing.T) {
 }
 
 func TestStateAddModule(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		In  []addrs.ModuleInstance
 		Out [][]string
@@ -118,6 +122,8 @@ func TestStateAddModule(t *testing.T) {
 }
 
 func TestStateDeepCopy(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		State *State
 	}{
@@ -177,7 +183,11 @@ func TestStateDeepCopy(t *testing.T) {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc
+
 		t.Run(fmt.Sprintf("copy-%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			actual := tc.State.DeepCopy()
 			expected := tc.State
 			if !reflect.DeepEqual(actual, expected) {
@@ -188,6 +198,8 @@ func TestStateDeepCopy(t *testing.T) {
 }
 
 func TestStateEqual(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name     string
 		Result   bool
@@ -377,7 +389,11 @@ func TestStateEqual(t *testing.T) {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc
+
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			t.Parallel()
+
 			if tc.One.Equal(tc.Two) != tc.Result {
 				t.Fatalf("Bad: %d\n\n%s\n\n%s", i, tc.One.String(), tc.Two.String())
 			}
@@ -389,6 +405,8 @@ func TestStateEqual(t *testing.T) {
 }
 
 func TestStateCompareAges(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Result   StateAgeComparison
 		Err      bool
@@ -481,6 +499,8 @@ func TestStateCompareAges(t *testing.T) {
 }
 
 func TestStateSameLineage(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Result   bool
 		One, Two *State
@@ -539,6 +559,8 @@ func TestStateSameLineage(t *testing.T) {
 }
 
 func TestStateRemove(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		Address  string
 		One, Two *State
@@ -824,6 +846,8 @@ func TestStateRemove(t *testing.T) {
 }
 
 func TestResourceStateEqual(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Result   bool
 		One, Two *ResourceState
@@ -911,6 +935,8 @@ func TestResourceStateEqual(t *testing.T) {
 }
 
 func TestInstanceStateEmpty(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		In     *InstanceState
 		Result bool
@@ -939,6 +965,8 @@ func TestInstanceStateEmpty(t *testing.T) {
 }
 
 func TestInstanceStateEqual(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Result   bool
 		One, Two *InstanceState
@@ -992,6 +1020,8 @@ func TestInstanceStateEqual(t *testing.T) {
 }
 
 func TestStateEmpty(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		In     *State
 		Result bool
@@ -1028,6 +1058,8 @@ func TestStateEmpty(t *testing.T) {
 }
 
 func TestStateHasResources(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		In     *State
 		Result bool
@@ -1086,6 +1118,8 @@ func TestStateHasResources(t *testing.T) {
 }
 
 func TestStateIsRemote(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		In     *State
 		Result bool
@@ -1114,6 +1148,8 @@ func TestStateIsRemote(t *testing.T) {
 }
 
 func TestInstanceState_MergeDiff(t *testing.T) {
+	t.Parallel()
+
 	is := InstanceState{
 		ID: "foo",
 		Attributes: map[string]string{
@@ -1160,6 +1196,8 @@ func TestInstanceState_MergeDiff(t *testing.T) {
 // right partial state. This never failed but is put here for completion
 // of the test case for GH-12183.
 func TestInstanceState_MergeDiff_computedSet(t *testing.T) {
+	t.Parallel()
+
 	is := InstanceState{}
 
 	diff := &InstanceDiff{
@@ -1196,6 +1234,8 @@ func TestInstanceState_MergeDiff_computedSet(t *testing.T) {
 }
 
 func TestInstanceState_MergeDiff_nil(t *testing.T) {
+	t.Parallel()
+
 	var is *InstanceState
 
 	diff := &InstanceDiff{
@@ -1219,6 +1259,8 @@ func TestInstanceState_MergeDiff_nil(t *testing.T) {
 }
 
 func TestInstanceState_MergeDiff_nilDiff(t *testing.T) {
+	t.Parallel()
+
 	is := InstanceState{
 		ID: "foo",
 		Attributes: map[string]string{
@@ -1238,6 +1280,8 @@ func TestInstanceState_MergeDiff_nilDiff(t *testing.T) {
 }
 
 func TestParseResourceStateKey(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Input       string
 		Expected    *ResourceStateKey
@@ -1304,6 +1348,8 @@ func TestParseResourceStateKey(t *testing.T) {
 }
 
 func TestResourceNameSort(t *testing.T) {
+	t.Parallel()
+
 	names := []string{
 		"a",
 		"b",

--- a/terraform/util_test.go
+++ b/terraform/util_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestUniqueStrings(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Input    []string
 		Expected []string
@@ -41,7 +43,11 @@ func TestUniqueStrings(t *testing.T) {
 	}
 
 	for i, tc := range cases {
+		i, tc := i, tc
+
 		t.Run(fmt.Sprintf("unique-%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			actual := uniqueStrings(tc.Input)
 			if !reflect.DeepEqual(tc.Expected, actual) {
 				t.Fatalf("Expected: %q\nGot: %q", tc.Expected, actual)


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/83
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/126

### Notes
- GH action already has golangci-lint in it 🤷🏻 -> https://github.com/hashicorp/terraform-plugin-testing/blob/0c072a29eb4de209d79a740fedc5d0774c22b2ab/.github/workflows/ci-go.yml#L24