### PR TITLE
helper/resource: Remove special timeouts logic in TestStep ImportStateVerify

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230213-155637.yaml
+++ b/.changes/unreleased/BUG FIXES-20230213-155637.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'helper/resource: Ensured ImportStateVerify can detect timeouts differences
+  that may result in an unclean plan after import'
+time: 2023-02-13T15:56:37.50139-05:00
+custom:
+  Issue: "54"

--- a/.changes/unreleased/NOTES-20230213-155943.yaml
+++ b/.changes/unreleased/NOTES-20230213-155943.yaml
@@ -1,0 +1,8 @@
+kind: NOTES
+body: 'helper/resource: ImportStateVerify will now return any timeouts block differences
+  which are significant on Terraform 1.3.8 or later. If ImportStateVerify reports
+  any differences, ensure any terraform-plugin-sdk/v2 dependency is version 2.25.0
+  or later.'
+time: 2023-02-13T15:59:43.653075-05:00
+custom:
+  Issue: "54"

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -240,26 +240,6 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 				}
 			}
 
-			// timeouts are only _sometimes_ added to state. To
-			// account for this, just don't compare timeouts at
-			// all.
-			for k := range actual {
-				if strings.HasPrefix(k, "timeouts.") {
-					delete(actual, k)
-				}
-				if k == "timeouts" {
-					delete(actual, k)
-				}
-			}
-			for k := range expected {
-				if strings.HasPrefix(k, "timeouts.") {
-					delete(expected, k)
-				}
-				if k == "timeouts" {
-					delete(expected, k)
-				}
-			}
-
 			if !reflect.DeepEqual(actual, expected) {
 				// Determine only the different attributes
 				// go-cmp tries to show surrounding identical map key/value for


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/1146
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/1147

This change reverts https://github.com/hashicorp/terraform-plugin-sdk/pull/576 as it prevents acceptance testing from detecting Terraform 1.3.8 and later potentially returning an unexpected plan after import involving the `timeouts` block. https://github.com/hashicorp/terraform-plugin-sdk/pull/1146 fixes the import logic to never include a known value for `timeouts`, which is what the acceptance testing was trying to say when this testing logic was not in place.

With this change, but without https://github.com/hashicorp/terraform-plugin-sdk/pull/1146 on a resource known to have the unexpected plan after import on Terraform 1.3.8:

```
=== CONT  TestAccVPCSecurityGroup_basic
    vpc_security_group_test.go:1002: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.

          map[string]string{
        +       "timeouts.%": "2",
          }
--- FAIL: TestAccVPCSecurityGroup_basic (21.54s)
```

With this change and with https://github.com/hashicorp/terraform-plugin-sdk/pull/1146:

```
=== CONT  TestAccVPCSecurityGroup_basic
--- PASS: TestAccVPCSecurityGroup_basic (20.23s)
```

Verified both ways on Terraform 1.2.9 as well (as a smoke test for a Terraform version prior to 1.3.8).