### PR TITLE
Upgrade tfexec to `v0.18.1` + add tests for `ExpectError`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/hc-install v0.5.0
 	github.com/hashicorp/hcl/v2 v2.16.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-exec v0.18.0
+	github.com/hashicorp/terraform-exec v0.18.1
 	github.com/hashicorp/terraform-json v0.15.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/hc-install v0.5.0
 	github.com/hashicorp/hcl/v2 v2.16.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-exec v0.17.3
+	github.com/hashicorp/terraform-exec v0.18.0
 	github.com/hashicorp/terraform-json v0.15.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/hc-install v0.5.0
 	github.com/hashicorp/hcl/v2 v2.16.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-exec v0.18.0
+	github.com/hashicorp/terraform-exec v0.17.3
 	github.com/hashicorp/terraform-json v0.15.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/hashicorp/hcl/v2 v2.16.1 h1:BwuxEMD/tsYgbhIW7UuI3crjovf3MzuFWiVgiv57i
 github.com/hashicorp/hcl/v2 v2.16.1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
+github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=
+github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
 github.com/hashicorp/terraform-exec v0.18.0 h1:BJa6/Fhxnb0zvsEGqUrFSybcnhAiBVSUgG7s09b6XlI=
 github.com/hashicorp/terraform-exec v0.18.0/go.mod h1:6PMRgg0Capig5Fn0zW9/+WM3vQsdwotwa8uxDVzLpHE=
 github.com/hashicorp/terraform-json v0.15.0 h1:/gIyNtR6SFw6h5yzlbDbACyGvIhKtQi8mTsbkNd79lE=

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/hashicorp/hcl/v2 v2.16.1 h1:BwuxEMD/tsYgbhIW7UuI3crjovf3MzuFWiVgiv57i
 github.com/hashicorp/hcl/v2 v2.16.1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=
-github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
 github.com/hashicorp/terraform-exec v0.18.0 h1:BJa6/Fhxnb0zvsEGqUrFSybcnhAiBVSUgG7s09b6XlI=
 github.com/hashicorp/terraform-exec v0.18.0/go.mod h1:6PMRgg0Capig5Fn0zW9/+WM3vQsdwotwa8uxDVzLpHE=
 github.com/hashicorp/terraform-json v0.15.0 h1:/gIyNtR6SFw6h5yzlbDbACyGvIhKtQi8mTsbkNd79lE=

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.18.0 h1:BJa6/Fhxnb0zvsEGqUrFSybcnhAiBVSUgG7s09b6XlI=
 github.com/hashicorp/terraform-exec v0.18.0/go.mod h1:6PMRgg0Capig5Fn0zW9/+WM3vQsdwotwa8uxDVzLpHE=
+github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=
+github.com/hashicorp/terraform-exec v0.18.1/go.mod h1:58wg4IeuAJ6LVsLUeD2DWZZoc/bYi6dzhLHzxM41980=
 github.com/hashicorp/terraform-json v0.15.0 h1:/gIyNtR6SFw6h5yzlbDbACyGvIhKtQi8mTsbkNd79lE=
 github.com/hashicorp/terraform-json v0.15.0/go.mod h1:+L1RNzjDU5leLFZkHTFTbJXaoqUC6TqXlFgDoOXrtvk=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=

--- a/helper/resource/testing_new_config_test.go
+++ b/helper/resource/testing_new_config_test.go
@@ -1,0 +1,28 @@
+package resource
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestTest_TestStep_ExpectError_NewConfig(t *testing.T) {
+	t.Parallel()
+
+	Test(t, TestCase{
+		ExternalProviders: map[string]ExternalProvider{
+			"random": {
+				Source:            "registry.terraform.io/hashicorp/random",
+				VersionConstraint: "3.4.3",
+			},
+		},
+		Steps: []TestStep{
+			{
+				Config: `resource "random_string" "one" {
+					length = 2
+					min_upper = 4
+				}`,
+				ExpectError: regexp.MustCompile(`Error: Invalid Attribute Value`),
+			},
+		},
+	})
+}

--- a/helper/resource/testing_new_import_state_test.go
+++ b/helper/resource/testing_new_import_state_test.go
@@ -6,6 +6,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -193,6 +194,28 @@ func TestTest_TestStep_ImportStateVerifyIgnore(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_only"},
+			},
+		},
+	})
+}
+
+func TestTest_TestStep_ExpectError_ImportState(t *testing.T) {
+	t.Parallel()
+
+	Test(t, TestCase{
+		ExternalProviders: map[string]ExternalProvider{
+			"random": {
+				Source:            "registry.terraform.io/hashicorp/time",
+				VersionConstraint: "0.9.1",
+			},
+		},
+		Steps: []TestStep{
+			{
+				Config:        `resource "time_static" "one" {}`,
+				ImportStateId: "invalid time string",
+				ResourceName:  "time_static.one",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile(`Error: Import time static error`),
 			},
 		},
 	})

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -30,9 +30,9 @@ func TestRetry(t *testing.T) {
 }
 
 // make sure a slow StateRefreshFunc is allowed to complete after timeout
+//
+//nolint:paralleltest // This test tends to fail when run in parallel and w/ test explorer
 func TestRetry_grace(t *testing.T) {
-	t.Parallel()
-
 	f := func() *RetryError {
 		time.Sleep(1 * time.Second)
 		return nil


### PR DESCRIPTION
## Background
A recent update of `tfexec`[v0.18.0](https://github.com/hashicorp/terraform-exec/releases/tag/v0.18.0) caused a regression where detailed stderr information wasn't being passed to this testing module. This has now been fixed with the new release [v0.18.1](https://github.com/hashicorp/terraform-exec/releases/tag/v0.18.1)


## Notes
- Added tests for ExpectError, so future CI can catch bugs similar to the one introduced in #58 
  - I'm not sure how to cause the `terraform refresh` command to fail, so I left that test out for now
  - Example of new tests [failing](https://github.com/hashicorp/terraform-plugin-testing/actions/runs/4304174942/jobs/7504818466#step:5:8) w/ tfexec `v0.18.0`
- Upgrading tfexec to `v0.18.1` to fix bug of error not containing stderr information: https://github.com/hashicorp/terraform-exec/pull/372
- Removed `t.Parallel()` from a test that was causing me some problems on my local
