### PR TITLE
Add source details to error message

### DIFF
--- a/internal/plugintest/config.go
+++ b/internal/plugintest/config.go
@@ -44,21 +44,27 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 	}
 
 	var sources []src.Source
+	// Upstream hc-install does not provide a String() method to identify the source, store details of each source to contextualize error during `installer.Ensure`
+	var sourceDetails []string
+
 	switch {
 	case tfPath != "":
-		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential Terraform CLI source of exact path: %s", tfPath))
+		sourceDetail := fmt.Sprintf("Terraform CLI source of exact path: %s", tfPath)
+		sourceDetails = append(sourceDetails, sourceDetail)
+		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential %s", sourceDetail))
 
 		sources = append(sources, &fs.AnyVersion{
 			ExactBinPath: tfPath,
 		})
 	case tfVersion != "":
 		tfVersion, err := version.NewVersion(tfVersion)
-
 		if err != nil {
 			return nil, fmt.Errorf("invalid Terraform version: %w", err)
 		}
 
-		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential Terraform CLI source of releases.hashicorp.com exact version %q for installation in: %s", tfVersion, tfDir))
+		sourceDetail := fmt.Sprintf("Terraform CLI source of releases.hashicorp.com exact version %q for installation in: %s", tfVersion, tfDir)
+		sourceDetails = append(sourceDetails, sourceDetail)
+		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential %s", sourceDetail))
 
 		sources = append(sources, &releases.ExactVersion{
 			InstallDir: tfDir,
@@ -66,12 +72,18 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 			Version:    tfVersion,
 		})
 	default:
-		logging.HelperResourceTrace(ctx, "Adding potential Terraform CLI source of local filesystem PATH lookup")
-		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential Terraform CLI source of checkpoint.hashicorp.com latest version for installation in: %s", tfDir))
+		sourceDetail := "Terraform CLI source of local filesystem PATH lookup"
+		sourceDetails = append(sourceDetails, sourceDetail)
+		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential %s", sourceDetail))
 
 		sources = append(sources, &fs.AnyVersion{
 			Product: &product.Terraform,
 		})
+
+		sourceDetail = fmt.Sprintf("Terraform CLI source of checkpoint.hashicorp.com latest version for installation in: %s", tfDir)
+		sourceDetails = append(sourceDetails, sourceDetail)
+		logging.HelperResourceTrace(ctx, fmt.Sprintf("Adding potential %s", sourceDetail))
+
 		sources = append(sources, &checkpoint.LatestVersion{
 			InstallDir: tfDir,
 			Product:    product.Terraform,
@@ -81,7 +93,7 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 	installer := install.NewInstaller()
 	tfExec, err := installer.Ensure(context.Background(), sources)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find or install Terraform CLI from %+v: %w", sources, err)
+		return nil, fmt.Errorf("error ensuring Terraform CLI binary: %w - sources: %v", err, sourceDetails)
 	}
 
 	ctx = logging.TestTerraformPathContext(ctx, tfExec)

--- a/internal/plugintest/config.go
+++ b/internal/plugintest/config.go
@@ -93,7 +93,7 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 	installer := install.NewInstaller()
 	tfExec, err := installer.Ensure(context.Background(), sources)
 	if err != nil {
-		return nil, fmt.Errorf("error ensuring Terraform CLI binary: %w - sources: %v", err, sourceDetails)
+		return nil, fmt.Errorf("error ensuring Terraform CLI binary: %w -  attempted source(s): %v", err, sourceDetails)
 	}
 
 	ctx = logging.TestTerraformPathContext(ctx, tfExec)


### PR DESCRIPTION
> A hackish fix to close #133, another alternative could be submitting a PR upstream to `hc-install` to add `Stringer` implementations for each `src.Source` implementation.

The upstream `hc-install` [`src.Source`](https://pkg.go.dev/github.com/hashicorp/hc-install@v0.5.2/src#Source) interface does not provide a `String()` function or equivalent to retrieve relevant information about the sources.

This PR takes some of the source detail from the logging message and adds all source detail information to the end of an error message. It's provides maybe too much information now instead of none 😆.

```bash
# Example w/ incorrect version env variable
cannot run Terraform provider tests: error ensuring Terraform CLI binary: failed to obtain product version from "https://releases.hashicorp.com/terraform/1.5.2/index.json": 404 Not Found  -  attempted source(s): [Terraform CLI source of releases.hashicorp.com exact version "1.5.2" for installation in: /var/folders/t8/1tjpvj_d24x8yl0st5qswzf80000gp/T/plugintest-terraform4283162721]

# Example w/ network error
cannot run Terraform provider tests: error ensuring Terraform CLI binary: Get "https://releases.hashicorp.com/terraform/1.5.0/index.json": dial tcp: lookup releases.hashicorp.com: no such host -  attempted source(s): [Terraform CLI source of releases.hashicorp.com exact version "1.5.0" for installation in: /var/folders/t8/1tjpvj_d24x8yl0st5qswzf80000gp/T/plugintest-terraform856199534]
```