### PR TITLE
website: Update GitHub Actions example for setup-go@v4 and using go.mod version

### DIFF
--- a/website/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/index.mdx
@@ -136,7 +136,7 @@ Create a [GitHub Actions workflow](https://docs.github.com/en/actions/using-work
 
 Use the [`matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) strategy for more advanced configuration, such as running acceptance testing against multiple Terraform CLI versions.
 
-The following example workflow runs acceptance testing for the provider using the latest patch versions of Go 1.19 and Terraform CLI 1.3:
+The following example workflow runs acceptance testing for the provider using the latest patch versions of the Go version in the `go.mod` file and Terraform CLI 1.5:
 
 ```yaml
 name: Terraform Provider Tests
@@ -157,12 +157,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: '1.3.*'
+          terraform_version: '1.5.*'
           terraform_wrapper: false
       - run: go test -v -cover ./...
         env:
@@ -172,14 +172,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - run: go test -v -cover ./...
 ```
 
 
-The following example workflow runs acceptance testing for the provider using the latest patch versions of Go 1.19 and Terraform CLI 0.12 through 1.3:
+The following example workflow runs acceptance testing for the provider using the latest patch versions of Go version in the `go.mod` file and Terraform CLI 0.12 through 1.5:
 
 ```yaml
 name: Terraform Provider Tests
@@ -210,11 +210,13 @@ jobs:
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
+          - '1.4.*'
+          - '1.5.*'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform-version }}
@@ -227,9 +229,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - run: go test -v -cover ./...
 ```
 


### PR DESCRIPTION
Reference: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file

This prevents developers from needing to continually update their testing workflow with Go upgrades, which can be pointed at the minimum Go version as defined by their Go module.