### PR TITLE
helper/resource: Refactor various unit testing to use inline providers

### DIFF
--- a/helper/resource/testing_new_import_state_test.go
+++ b/helper/resource/testing_new_import_state_test.go
@@ -4,14 +4,17 @@
 package resource
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/datasource"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -19,50 +22,79 @@ func TestTest_TestStep_ImportStateCheck_SkipDataSourceState(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"examplecloud": func() (*schema.Provider, error) { //nolint:unparam // required signature
-				return &schema.Provider{
-					DataSourcesMap: map[string]*schema.Resource{
-						"examplecloud_thing": {
-							ReadContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								d.SetId("datasource-test")
-
-								return nil
-							},
-							Schema: map[string]*schema.Schema{
-								"id": {
-									Type:     schema.TypeString,
-									Computed: true,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				DataSources: map[string]testprovider.DataSource{
+					"examplecloud_thing": {
+						ReadResponse: &datasource.ReadResponse{
+							State: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"id": tftypes.NewValue(tftypes.String, "datasource-test"),
+								},
+							),
+						},
+						SchemaResponse: &datasource.SchemaResponse{
+							Schema: &tfprotov6.Schema{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "id",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+									},
 								},
 							},
 						},
 					},
-					ResourcesMap: map[string]*schema.Resource{
-						"examplecloud_thing": {
-							CreateContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								d.SetId("resource-test")
-
-								return nil
-							},
-							DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								return nil
-							},
-							ReadContext: func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								return nil
-							},
-							Schema: map[string]*schema.Schema{
-								"id": {
-									Computed: true,
-									Type:     schema.TypeString,
+				},
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_thing": {
+						CreateResponse: &resource.CreateResponse{
+							NewState: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id": tftypes.String,
+									},
 								},
-							},
-							Importer: &schema.ResourceImporter{
-								StateContext: schema.ImportStatePassthroughContext,
+								map[string]tftypes.Value{
+									"id": tftypes.NewValue(tftypes.String, "resource-test"),
+								},
+							),
+						},
+						ImportStateResponse: &resource.ImportStateResponse{
+							State: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"id": tftypes.NewValue(tftypes.String, "resource-test"),
+								},
+							),
+						},
+						SchemaResponse: &resource.SchemaResponse{
+							Schema: &tfprotov6.Schema{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "id",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+									},
+								},
 							},
 						},
 					},
-				}, nil
-			},
+				},
+			}),
 		},
 		Steps: []TestStep{
 			{
@@ -90,41 +122,59 @@ func TestTest_TestStep_ImportStateVerify(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"examplecloud": func() (*schema.Provider, error) { //nolint:unparam // required signature
-				return &schema.Provider{
-					ResourcesMap: map[string]*schema.Resource{
-						"examplecloud_thing": {
-							CreateContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								d.SetId("resource-test")
-
-								return nil
-							},
-							DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								return nil
-							},
-							ReadContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								_ = d.Set("other", "testvalue")
-
-								return nil
-							},
-							Schema: map[string]*schema.Schema{
-								"other": {
-									Computed: true,
-									Type:     schema.TypeString,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_thing": {
+						CreateResponse: &resource.CreateResponse{
+							NewState: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id":    tftypes.String,
+										"other": tftypes.String,
+									},
 								},
-								"id": {
-									Computed: true,
-									Type:     schema.TypeString,
+								map[string]tftypes.Value{
+									"id":    tftypes.NewValue(tftypes.String, "resource-test"),
+									"other": tftypes.NewValue(tftypes.String, "testvalue"),
 								},
-							},
-							Importer: &schema.ResourceImporter{
-								StateContext: schema.ImportStatePassthroughContext,
+							),
+						},
+						ImportStateResponse: &resource.ImportStateResponse{
+							State: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id":    tftypes.String,
+										"other": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"id":    tftypes.NewValue(tftypes.String, "resource-test"),
+									"other": tftypes.NewValue(tftypes.String, "testvalue"),
+								},
+							),
+						},
+						SchemaResponse: &resource.SchemaResponse{
+							Schema: &tfprotov6.Schema{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "id",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+										{
+											Name:     "other",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+									},
+								},
 							},
 						},
 					},
-				}, nil
-			},
+				},
+			}),
 		},
 		Steps: []TestStep{
 			{
@@ -143,47 +193,68 @@ func TestTest_TestStep_ImportStateVerifyIgnore(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"examplecloud": func() (*schema.Provider, error) { //nolint:unparam // required signature
-				return &schema.Provider{
-					ResourcesMap: map[string]*schema.Resource{
-						"examplecloud_thing": {
-							CreateContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								d.SetId("resource-test")
-
-								_ = d.Set("create_only", "testvalue")
-
-								return nil
-							},
-							DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								return nil
-							},
-							ReadContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-								_ = d.Set("read_only", "testvalue")
-
-								return nil
-							},
-							Schema: map[string]*schema.Schema{
-								"create_only": {
-									Computed: true,
-									Type:     schema.TypeString,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_thing": {
+						CreateResponse: &resource.CreateResponse{
+							NewState: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id":          tftypes.String,
+										"create_only": tftypes.String,
+										"read_only":   tftypes.String,
+									},
 								},
-								"read_only": {
-									Computed: true,
-									Type:     schema.TypeString,
+								map[string]tftypes.Value{
+									"id":          tftypes.NewValue(tftypes.String, "resource-test"),
+									"create_only": tftypes.NewValue(tftypes.String, "testvalue"),
+									"read_only":   tftypes.NewValue(tftypes.String, "testvalue"),
 								},
-								"id": {
-									Computed: true,
-									Type:     schema.TypeString,
+							),
+						},
+						ImportStateResponse: &resource.ImportStateResponse{
+							State: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id":          tftypes.String,
+										"create_only": tftypes.String,
+										"read_only":   tftypes.String,
+									},
 								},
-							},
-							Importer: &schema.ResourceImporter{
-								StateContext: schema.ImportStatePassthroughContext,
+								map[string]tftypes.Value{
+									"id":          tftypes.NewValue(tftypes.String, "resource-test"),
+									"create_only": tftypes.NewValue(tftypes.String, nil), // intentional
+									"read_only":   tftypes.NewValue(tftypes.String, "testvalue"),
+								},
+							),
+						},
+						SchemaResponse: &resource.SchemaResponse{
+							Schema: &tfprotov6.Schema{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "create_only",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+										{
+											Name:     "id",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+										{
+											Name:     "read_only",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+									},
+								},
 							},
 						},
 					},
-				}, nil
-			},
+				},
+			}),
 		},
 		Steps: []TestStep{
 			{
@@ -202,20 +273,56 @@ func TestTest_TestStep_ImportStateVerifyIgnore(t *testing.T) {
 func TestTest_TestStep_ExpectError_ImportState(t *testing.T) {
 	t.Parallel()
 
-	Test(t, TestCase{
-		ExternalProviders: map[string]ExternalProvider{
-			"random": {
-				Source:            "registry.terraform.io/hashicorp/time",
-				VersionConstraint: "0.9.1",
-			},
+	UnitTest(t, TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"test": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"test_resource": {
+						CreateResponse: &resource.CreateResponse{
+							NewState: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"id": tftypes.NewValue(tftypes.String, "resource-test"),
+								},
+							),
+						},
+						ImportStateResponse: &resource.ImportStateResponse{
+							Diagnostics: []*tfprotov6.Diagnostic{
+								{
+									Severity: tfprotov6.DiagnosticSeverityError,
+									Summary:  "Invalid Import ID",
+									Detail:   "Diagnostic details",
+								},
+							},
+						},
+						SchemaResponse: &resource.SchemaResponse{
+							Schema: &tfprotov6.Schema{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "id",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 		Steps: []TestStep{
 			{
-				Config:        `resource "time_static" "one" {}`,
+				Config:        `resource "test_resource" "test" {}`,
 				ImportStateId: "invalid time string",
-				ResourceName:  "time_static.one",
+				ResourceName:  "test_resource.test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Error: Import time static error`),
+				ExpectError:   regexp.MustCompile(`Error: Invalid Import ID`),
 			},
 		},
 	})


### PR DESCRIPTION
Closes #151

This will reduce CI time and dependency on networking/registry calls. Other unit testing that can be refactored can be done when the terraform-plugin-sdk dependency is being removed.