### PR TITLE
terraform: Add deprecation Go documentation comments

### DIFF
--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -21,7 +21,7 @@ type shimmedState struct {
 }
 
 func shimStateFromJson(jsonState *tfjson.State) (*terraform.State, error) {
-	state := terraform.NewState()
+	state := terraform.NewState() //nolint:staticcheck // legacy usage
 	state.TFVersion = jsonState.TerraformVersion
 
 	if jsonState.Values == nil {
@@ -124,7 +124,7 @@ func (ss *shimmedState) shimStateModule(sm *tfjson.StateModule) error {
 		}
 	}
 
-	mod := ss.state.AddModule(path)
+	mod := ss.state.AddModule(path) //nolint:staticcheck // legacy usage
 	for _, res := range sm.Resources {
 		resourceState, err := shimResourceState(res)
 		if err != nil {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1548,7 +1548,7 @@ func testCheckResourceAttrPair(isFirst *terraform.InstanceState, nameFirst strin
 // TestCheckOutput checks an output in the Terraform configuration
 func TestCheckOutput(name, value string) TestCheckFunc {
 	return func(s *terraform.State) error {
-		ms := s.RootModule()
+		ms := s.RootModule() //nolint:staticcheck // legacy usage
 		rs, ok := ms.Outputs[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
@@ -1568,7 +1568,7 @@ func TestCheckOutput(name, value string) TestCheckFunc {
 
 func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
 	return func(s *terraform.State) error {
-		ms := s.RootModule()
+		ms := s.RootModule() //nolint:staticcheck // legacy usage
 		rs, ok := ms.Outputs[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
@@ -1610,7 +1610,7 @@ func modulePrimaryInstanceState(ms *terraform.ModuleState, name string) (*terraf
 // modulePathPrimaryInstanceState returns the primary instance state for the
 // given resource name in a given module path.
 func modulePathPrimaryInstanceState(s *terraform.State, mp addrs.ModuleInstance, name string) (*terraform.InstanceState, error) {
-	ms := s.ModuleByPath(mp)
+	ms := s.ModuleByPath(mp) //nolint:staticcheck // legacy usage
 	if ms == nil {
 		return nil, fmt.Errorf("No module found at: %s", mp)
 	}
@@ -1621,7 +1621,7 @@ func modulePathPrimaryInstanceState(s *terraform.State, mp addrs.ModuleInstance,
 // primaryInstanceState returns the primary instance state for the given
 // resource name in the root module.
 func primaryInstanceState(s *terraform.State, name string) (*terraform.InstanceState, error) {
-	ms := s.RootModule()
+	ms := s.RootModule() //nolint:staticcheck // legacy usage
 	return modulePrimaryInstanceState(ms, name)
 }
 
@@ -1640,7 +1640,7 @@ func indexesIntoTypeSet(key string) bool {
 func checkIfIndexesIntoTypeSet(key string, f TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
 		err := f(s)
-		if err != nil && s.IsBinaryDrivenTest && indexesIntoTypeSet(key) {
+		if err != nil && indexesIntoTypeSet(key) {
 			return fmt.Errorf("Error in test check: %s\nTest check address %q likely indexes into TypeSet\nThis is currently not possible in the SDK", err, key)
 		}
 		return err
@@ -1650,7 +1650,7 @@ func checkIfIndexesIntoTypeSet(key string, f TestCheckFunc) TestCheckFunc {
 func checkIfIndexesIntoTypeSetPair(keyFirst, keySecond string, f TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
 		err := f(s)
-		if err != nil && s.IsBinaryDrivenTest && (indexesIntoTypeSet(keyFirst) || indexesIntoTypeSet(keySecond)) {
+		if err != nil && (indexesIntoTypeSet(keyFirst) || indexesIntoTypeSet(keySecond)) {
 			return fmt.Errorf("Error in test check: %s\nTest check address %q or %q likely indexes into TypeSet\nThis is currently not possible in the SDK", err, keyFirst, keySecond)
 		}
 		return err

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1548,7 +1548,7 @@ func testCheckResourceAttrPair(isFirst *terraform.InstanceState, nameFirst strin
 // TestCheckOutput checks an output in the Terraform configuration
 func TestCheckOutput(name, value string) TestCheckFunc {
 	return func(s *terraform.State) error {
-		ms := s.RootModule() //nolint:staticcheck // legacy usage
+		ms := s.RootModule()
 		rs, ok := ms.Outputs[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
@@ -1568,7 +1568,7 @@ func TestCheckOutput(name, value string) TestCheckFunc {
 
 func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
 	return func(s *terraform.State) error {
-		ms := s.RootModule() //nolint:staticcheck // legacy usage
+		ms := s.RootModule()
 		rs, ok := ms.Outputs[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -356,7 +356,7 @@ func getState(ctx context.Context, t testing.T, wd *plugintest.WorkingDir) (*ter
 }
 
 func stateIsEmpty(state *terraform.State) bool {
-	return state.Empty() || !state.HasResources()
+	return state.Empty() || !state.HasResources() //nolint:staticcheck // legacy usage
 }
 
 func planIsEmpty(plan *tfjson.Plan) bool {
@@ -375,7 +375,7 @@ func testIDRefresh(ctx context.Context, t testing.T, c TestCase, wd *plugintest.
 
 	// Build the state. The state is just the resource with an ID. There
 	// are no attributes. We only set what is needed to perform a refresh.
-	state := terraform.NewState()
+	state := terraform.NewState() //nolint:staticcheck // legacy usage
 	state.RootModule().Resources = make(map[string]*terraform.ResourceState)
 	state.RootModule().Resources[c.IDRefreshName] = &terraform.ResourceState{}
 

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -112,7 +112,6 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 		if step.Check != nil {
 			logging.HelperResourceTrace(ctx, "Using TestStep Check")
 
-			state.IsBinaryDrivenTest = true
 			if step.Destroy {
 				if err := step.Check(stateBeforeApplication); err != nil {
 					return fmt.Errorf("Check failed: %w", err)
@@ -244,6 +243,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 			return err
 		}
 
+		//nolint:staticcheck // legacy usage
 		if state.Empty() {
 			return nil
 		}

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -147,7 +147,7 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 				continue
 			}
 
-			is := r.Primary.DeepCopy()
+			is := r.Primary.DeepCopy() //nolint:staticcheck // legacy usage
 			is.Ephemeral.Type = r.Type // otherwise the check function cannot see the type
 			states = append(states, is)
 		}

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -867,7 +867,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 	}{
 		"attribute not found": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -887,7 +886,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"bool attribute match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -908,7 +906,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"bool attribute mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -930,7 +927,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"float attribute match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -951,7 +947,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"float attribute mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -973,7 +968,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"integer attribute match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -994,7 +988,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"integer attribute mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1016,7 +1009,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"list attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1039,7 +1031,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"list attribute element count match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1061,7 +1052,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"list attribute element count mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1084,7 +1074,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"list attribute element count match 0 when empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1106,7 +1095,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		// Special case with .# and value 0
 		"list attribute element count match 0 when missing": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1125,7 +1113,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"list attribute element value match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1147,7 +1134,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"list attribute element value mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1170,7 +1156,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"map attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1193,7 +1178,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"map attribute element count match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1215,7 +1199,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"map attribute element count mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1238,7 +1221,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"map attribute element count match 0 when empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1260,7 +1242,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		// Special case with .% and value 0
 		"map attribute element count match 0 when missing": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1279,7 +1260,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"map attribute element value match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1301,7 +1281,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"map attribute element value mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1324,7 +1303,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"set attribute indexing error": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1347,7 +1325,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"string attribute match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1368,7 +1345,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 		},
 		"string attribute mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1426,7 +1402,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 	}{
 		"attribute not found": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1446,7 +1421,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"bool attribute match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1467,7 +1441,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"bool attribute mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1489,7 +1462,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"list attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1512,7 +1484,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"list attribute element count match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1534,7 +1505,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"list attribute element count mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1557,7 +1527,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"list attribute element count match 0 when empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1578,7 +1547,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"list attribute element value match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1600,7 +1568,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"list attribute element value mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1623,7 +1590,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"map attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1646,7 +1612,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"map attribute element count match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1668,7 +1633,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"map attribute element count mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1691,7 +1655,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"map attribute element count match 0 when empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1712,7 +1675,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"map attribute element value match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1734,7 +1696,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"map attribute element value mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1757,7 +1718,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"set attribute indexing error": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1780,7 +1740,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"string attribute match": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1801,7 +1760,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 		},
 		"string attribute mismatch": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1863,7 +1821,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 	}{
 		"attribute not found": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1881,7 +1838,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		},
 		"attribute found": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1902,7 +1858,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		},
 		"list attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1925,7 +1880,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		// Special case with .# and value 0
 		"list attribute element count match 0 when empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1945,7 +1899,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		},
 		"list attribute element count mismatch 0 when non-empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1967,7 +1920,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		},
 		"map attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -1990,7 +1942,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		// Special case with .% and value 0
 		"map attribute element count match 0 when empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2010,7 +1961,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		},
 		"map attribute element count mismatch 0 when non-empty": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2032,7 +1982,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 		},
 		"set attribute indexing error": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2385,7 +2334,6 @@ func TestTestCheckResourceAttrSet(t *testing.T) {
 	}{
 		"attribute not found": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2404,7 +2352,6 @@ func TestTestCheckResourceAttrSet(t *testing.T) {
 		},
 		"attribute found": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2424,7 +2371,6 @@ func TestTestCheckResourceAttrSet(t *testing.T) {
 		},
 		"list attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2446,7 +2392,6 @@ func TestTestCheckResourceAttrSet(t *testing.T) {
 		},
 		"map attribute directly": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},
@@ -2468,7 +2413,6 @@ func TestTestCheckResourceAttrSet(t *testing.T) {
 		},
 		"set attribute indexing error": {
 			state: &terraform.State{
-				IsBinaryDrivenTest: true, // Always true now
 				Modules: []*terraform.ModuleState{
 					{
 						Path: []string{"root"},

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -35,6 +35,10 @@ const (
 var multiVal = regexp.MustCompile(`\.(#|%)$`)
 
 // InstanceDiff is the diff of a resource from some state to another.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type InstanceDiff struct {
 	mu             sync.Mutex
 	Attributes     map[string]*ResourceAttrDiff
@@ -53,7 +57,14 @@ type InstanceDiff struct {
 	Meta map[string]interface{}
 }
 
-func (d *InstanceDiff) Lock()   { d.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (d *InstanceDiff) Lock() { d.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) Unlock() { d.mu.Unlock() }
 
 // ApplyToValue merges the receiver into the given base value, returning a
@@ -62,6 +73,10 @@ func (d *InstanceDiff) Unlock() { d.mu.Unlock() }
 //
 // This method is intended for shimming old subsystems that still use this
 // legacy diff type to work with the new-style types.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) ApplyToValue(base cty.Value, schema *configschema.Block) (cty.Value, error) {
 	// Create an InstanceState attributes from our existing state.
 	// We can use this to more easily apply the diff changes.
@@ -84,6 +99,10 @@ func (d *InstanceDiff) ApplyToValue(base cty.Value, schema *configschema.Block) 
 //
 // This method is intended for shimming old subsystems that still use this
 // legacy diff type to work with the new-style types.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) Apply(attrs map[string]string, schema *configschema.Block) (map[string]string, error) {
 	// We always build a new value here, even if the given diff is "empty",
 	// because we might be planning to create a new instance that happens
@@ -604,6 +623,10 @@ func countFlatmapContainerValues(key string, attrs map[string]string) string {
 }
 
 // ResourceAttrDiff is the diff of a single attribute of a resource.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type ResourceAttrDiff struct {
 	Old         string      // Old Value
 	New         string      // New Value
@@ -626,12 +649,19 @@ func (d *ResourceAttrDiff) GoString() string {
 // "private_ip".
 type diffAttrType byte
 
+// Deprecated: This function is unintentionally exported by this Go module and
+// not supported for external consumption. It will be removed in the next major
+// version.
 func NewInstanceDiff() *InstanceDiff {
 	return &InstanceDiff{Attributes: make(map[string]*ResourceAttrDiff)}
 }
 
 // ChangeType returns the diffChangeType represented by the diff
 // for this single instance.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) ChangeType() diffChangeType {
 	if d.Empty() {
 		return diffNone
@@ -653,6 +683,10 @@ func (d *InstanceDiff) ChangeType() diffChangeType {
 }
 
 // Empty returns true if this diff encapsulates no changes.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) Empty() bool {
 	if d == nil {
 		return true
@@ -693,6 +727,10 @@ func (d *InstanceDiff) GoString() string {
 
 // RequiresNew returns true if the diff requires the creation of a new
 // resource (implying the destruction of the old).
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) RequiresNew() bool {
 	if d == nil {
 		return false
@@ -722,6 +760,9 @@ func (d *InstanceDiff) requiresNew() bool {
 	return false
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) GetDestroyDeposed() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -729,6 +770,9 @@ func (d *InstanceDiff) GetDestroyDeposed() bool {
 	return d.DestroyDeposed
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) GetDestroyTainted() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -736,6 +780,9 @@ func (d *InstanceDiff) GetDestroyTainted() bool {
 	return d.DestroyTainted
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) GetDestroy() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -743,6 +790,9 @@ func (d *InstanceDiff) GetDestroy() bool {
 	return d.Destroy
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) GetAttribute(key string) (*ResourceAttrDiff, bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -752,6 +802,10 @@ func (d *InstanceDiff) GetAttribute(key string) (*ResourceAttrDiff, bool) {
 }
 
 // Safely copies the Attributes map
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) CopyAttributes() map[string]*ResourceAttrDiff {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -768,6 +822,10 @@ func (d *InstanceDiff) CopyAttributes() map[string]*ResourceAttrDiff {
 // we say "same", it is not necessarily exactly equal. Instead, it is
 // just checking that the same attributes are changing, a destroy
 // isn't suddenly happening, etc.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 	// we can safely compare the pointers without a lock
 	switch {

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -20,6 +20,10 @@ import (
 
 // InstanceInfo is used to hold information about the instance and/or
 // resource being modified.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type InstanceInfo struct {
 	// Id is a unique name to represent this instance. This is not related
 	// to InstanceState.ID in any way.
@@ -36,6 +40,10 @@ type InstanceInfo struct {
 // ResourceConfig is a legacy type that was formerly used to represent
 // interpolatable configuration blocks. It is now only used to shim to old
 // APIs that still use this type, via NewResourceConfigShimmed.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type ResourceConfig struct {
 	ComputedKeys []string
 	Raw          map[string]interface{}
@@ -48,6 +56,10 @@ type ResourceConfig struct {
 // The given value may contain hcl2shim.UnknownVariableValue to signal that
 // something is computed, but it must not contain unprocessed interpolation
 // sequences as we might've seen in Terraform v0.11 and prior.
+//
+// Deprecated: This function is unintentionally exported by this Go module and
+// not supported for external consumption. It will be removed in the next major
+// version. Use real Terraform configuration instead.
 func NewResourceConfigRaw(raw map[string]interface{}) *ResourceConfig {
 	v := hcl2shim.HCL2ValueFromConfigValue(raw)
 
@@ -79,6 +91,10 @@ func NewResourceConfigRaw(raw map[string]interface{}) *ResourceConfig {
 //
 // If the given value is not of an object type that conforms to the given
 // schema then this function will panic.
+//
+// Deprecated: This function is unintentionally exported by this Go module and
+// not supported for external consumption. It will be removed in the next major
+// version.
 func NewResourceConfigShimmed(val cty.Value, schema *configschema.Block) *ResourceConfig {
 	if !val.Type().IsObjectType() {
 		panic(fmt.Errorf("NewResourceConfigShimmed given %#v; an object type is required", val.Type()))
@@ -151,6 +167,10 @@ func newResourceConfigShimmedComputedKeys(val cty.Value, path string) []string {
 // DeepCopy performs a deep copy of the configuration. This makes it safe
 // to modify any of the structures that are part of the resource config without
 // affecting the original configuration.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 	// DeepCopying a nil should return a nil to avoid panics
 	if c == nil {
@@ -206,6 +226,10 @@ func (c *ResourceConfig) Equal(c2 *ResourceConfig) bool {
 // The second return value is true if the get was successful. Get will
 // return the raw value if the key is computed, so you should pair this
 // with IsComputed.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (c *ResourceConfig) Get(k string) (interface{}, bool) {
 	// We aim to get a value from the configuration. If it is computed,
 	// then we return the pure raw value.
@@ -222,11 +246,19 @@ func (c *ResourceConfig) Get(k string) (interface{}, bool) {
 //
 // The second return value is true if the get was successful. Get will
 // not succeed if the value is being computed.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (c *ResourceConfig) GetRaw(k string) (interface{}, bool) {
 	return c.get(k, c.Raw)
 }
 
 // IsComputed returns whether the given key is computed or not.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (c *ResourceConfig) IsComputed(k string) bool {
 	// The next thing we do is check the config if we get a computed
 	// value out of it.

--- a/terraform/resource_provider.go
+++ b/terraform/resource_provider.go
@@ -4,6 +4,10 @@
 package terraform
 
 // ResourceType is a type of resource that a resource provider can manage.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type ResourceType struct {
 	Name       string // Name of the resource, example "instance" (no provider prefix)
 	Importable bool   // Whether this resource supports importing
@@ -17,6 +21,10 @@ type ResourceType struct {
 }
 
 // DataSource is a data source that a resource provider implements.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type DataSource struct {
 	Name string
 

--- a/terraform/schemas.go
+++ b/terraform/schemas.go
@@ -13,6 +13,10 @@ import (
 // The completeness of this structure depends on how it was constructed.
 // When constructed for a configuration, it will generally include only
 // resource types and data sources used by that configuration.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type ProviderSchema struct {
 	Provider      *configschema.Block
 	ResourceTypes map[string]*configschema.Block
@@ -23,6 +27,10 @@ type ProviderSchema struct {
 
 // ProviderSchemaRequest is used to describe to a ResourceProvider which
 // aspects of schema are required, when calling the GetSchema method.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type ProviderSchemaRequest struct {
 	ResourceTypes []string
 	DataSources   []string

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -92,11 +92,19 @@ type State struct {
 
 	// Remote is used to track the metadata required to
 	// pull and push state files from a remote storage endpoint.
+	//
+	// Deprecated: This field is unintentionally exported by this Go module and
+	// external consumption is not supported. It will be removed in the next
+	// major version.
 	Remote *RemoteState `json:"remote,omitempty"`
 
 	// Backend tracks the configuration for the backend in use with
 	// this state. This is used to track any changes in the backend
 	// configuration.
+	//
+	// Deprecated: This field is unintentionally exported by this Go module and
+	// external consumption is not supported. It will be removed in the next
+	// major version.
 	Backend *BackendState `json:"backend,omitempty"`
 
 	// Modules contains all the modules in a breadth-first order
@@ -106,13 +114,28 @@ type State struct {
 
 	// IsBinaryDrivenTest is a special flag that assists with a binary driver
 	// heuristic, it should not be set externally
+	//
+	// Deprecated: This field is unintentionally exported by this Go module and
+	// external consumption is not supported. It will be removed in the next
+	// major version.
 	IsBinaryDrivenTest bool
 }
 
-func (s *State) Lock()   { s.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (s *State) Lock() { s.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Unlock() { s.mu.Unlock() }
 
 // NewState is used to initialize a blank state
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func NewState() *State {
 	s := &State{}
 	s.init()
@@ -122,6 +145,10 @@ func NewState() *State {
 // Children returns the ModuleStates that are direct children of
 // the given path. If the path is "root", for example, then children
 // returned might be "root.child", but not "root.child.grandchild".
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Children(path []string) []*ModuleState {
 	s.Lock()
 	defer s.Unlock()
@@ -154,6 +181,10 @@ func (s *State) children(path []string) []*ModuleState {
 //
 // This should be the preferred method to add module states since it
 // allows us to optimize lookups later as well as control sorting.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) AddModule(path addrs.ModuleInstance) *ModuleState {
 	s.Lock()
 	defer s.Unlock()
@@ -200,6 +231,10 @@ func (s *State) addModule(path addrs.ModuleInstance) *ModuleState {
 // ModuleByPath is used to lookup the module state for the given path.
 // This should be the preferred lookup mechanism as it allows for future
 // lookup optimizations.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) ModuleByPath(path addrs.ModuleInstance) *ModuleState {
 	if s == nil {
 		return nil
@@ -227,6 +262,10 @@ func (s *State) moduleByPath(path addrs.ModuleInstance) *ModuleState {
 }
 
 // Empty returns true if the state is empty.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Empty() bool {
 	if s == nil {
 		return true
@@ -241,6 +280,10 @@ func (s *State) Empty() bool {
 //
 // This is similar to !s.Empty, but returns true also in the case where the
 // state has modules but all of them are devoid of resources.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) HasResources() bool {
 	if s.Empty() {
 		return false
@@ -257,6 +300,10 @@ func (s *State) HasResources() bool {
 
 // IsRemote returns true if State represents a state that exists and is
 // remote.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) IsRemote() bool {
 	if s == nil {
 		return false
@@ -283,6 +330,10 @@ func (s *State) IsRemote() bool {
 //
 // If this returns an error, then the user should be notified. The error
 // response will include detailed information on the nature of the error.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Validate() error {
 	s.Lock()
 	defer s.Unlock()
@@ -327,6 +378,10 @@ func (s *State) Validate() error {
 // If the address references a module state or resource, it will delete
 // all children as well. To check what will be deleted, use a StateFilter
 // first.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Remove(addr ...string) error {
 	s.Lock()
 	defer s.Unlock()
@@ -437,6 +492,10 @@ func (s *State) RootModule() *ModuleState {
 }
 
 // Equal tests if one state is equal to another.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Equal(other *State) bool {
 	// If one is nil, we do a direct check
 	if s == nil || other == nil {
@@ -478,6 +537,9 @@ func (s *State) equal(other *State) bool {
 	return true
 }
 
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type StateAgeComparison int
 
 const (
@@ -498,6 +560,10 @@ const (
 // the argument, positive if the converse, and zero if they are equal.
 // An error is returned if the two states are not of the same lineage,
 // in which case the integer returned has no meaning.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) CompareAges(other *State) (StateAgeComparison, error) {
 	// nil states are "older" than actual states
 	switch {
@@ -530,6 +596,10 @@ func (s *State) CompareAges(other *State) (StateAgeComparison, error) {
 
 // SameLineage returns true only if the state given in argument belongs
 // to the same "lineage" of states as the receiver.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) SameLineage(other *State) bool {
 	s.Lock()
 	defer s.Unlock()
@@ -547,6 +617,10 @@ func (s *State) SameLineage(other *State) bool {
 
 // DeepCopy performs a deep copy of the state structure and returns
 // a new structure.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) DeepCopy() *State {
 	if s == nil {
 		return nil
@@ -565,6 +639,9 @@ func (s *State) DeepCopy() *State {
 	return state
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) Init() {
 	s.Lock()
 	defer s.Unlock()
@@ -593,6 +670,9 @@ func (s *State) init() {
 
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) EnsureHasLineage() {
 	s.Lock()
 	defer s.Unlock()
@@ -618,6 +698,10 @@ func (s *State) ensureHasLineage() {
 }
 
 // AddModuleState insert this module state and override any existing ModuleState
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *State) AddModuleState(mod *ModuleState) {
 	mod.init()
 	s.Lock()
@@ -709,6 +793,10 @@ func (s *State) String() string {
 }
 
 // BackendState stores the configuration to connect to a remote backend.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type BackendState struct {
 	Type      string          `json:"type"`   // Backend type
 	ConfigRaw json.RawMessage `json:"config"` // Backend raw config
@@ -717,6 +805,10 @@ type BackendState struct {
 
 // RemoteState is used to track the information about a remote
 // state store that we push/pull state to.
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type RemoteState struct {
 	// Type controls the client we use for the remote state
 	Type string `json:"type"`
@@ -728,7 +820,14 @@ type RemoteState struct {
 	mu sync.Mutex
 }
 
-func (s *RemoteState) Lock()   { s.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (s *RemoteState) Lock() { s.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *RemoteState) Unlock() { s.mu.Unlock() }
 
 func (r *RemoteState) init() {
@@ -740,6 +839,9 @@ func (r *RemoteState) init() {
 	}
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (r *RemoteState) Empty() bool {
 	if r == nil {
 		return true
@@ -765,7 +867,14 @@ type OutputState struct {
 	mu sync.Mutex
 }
 
-func (s *OutputState) Lock()   { s.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (s *OutputState) Lock() { s.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *OutputState) Unlock() { s.mu.Unlock() }
 
 func (s *OutputState) String() string {
@@ -774,6 +883,10 @@ func (s *OutputState) String() string {
 
 // Equal compares two OutputState structures for equality. nil values are
 // considered equal.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *OutputState) Equal(other *OutputState) bool {
 	if s == nil && other == nil {
 		return true
@@ -840,7 +953,14 @@ type ModuleState struct {
 	mu sync.Mutex
 }
 
-func (s *ModuleState) Lock()   { s.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (s *ModuleState) Lock() { s.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *ModuleState) Unlock() { s.mu.Unlock() }
 
 // Equal tests whether one module state is equal to another.
@@ -1202,7 +1322,14 @@ type ResourceState struct {
 	mu sync.Mutex
 }
 
-func (s *ResourceState) Lock()   { s.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (s *ResourceState) Lock() { s.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *ResourceState) Unlock() { s.mu.Unlock() }
 
 // Equal tests whether two ResourceStates are equal.
@@ -1323,7 +1450,14 @@ type InstanceState struct {
 	mu sync.Mutex
 }
 
-func (s *InstanceState) Lock()   { s.mu.Lock() }
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
+func (s *InstanceState) Lock() { s.mu.Lock() }
+
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *InstanceState) Unlock() { s.mu.Unlock() }
 
 func (s *InstanceState) init() {
@@ -1344,6 +1478,10 @@ func (s *InstanceState) init() {
 // legacy InstanceState representation.
 //
 // This is for shimming to old components only and should not be used in new code.
+//
+// Deprecated: This function is unintentionally exported by this Go module and
+// not supported for external consumption. It will be removed in the next major
+// version.
 func NewInstanceStateShimmedFromValue(state cty.Value, schemaVersion int) *InstanceState {
 	attrs := hcl2shim.FlatmapValueFromHCL2(state)
 	return &InstanceState{
@@ -1364,6 +1502,10 @@ func NewInstanceStateShimmedFromValue(state cty.Value, schemaVersion int) *Insta
 //
 // This is for shimming from old components only and should not be used in
 // new code.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *InstanceState) AttrsAsObjectValue(ty cty.Type) (cty.Value, error) {
 	if s == nil {
 		// if the state is nil, we need to construct a complete cty.Value with
@@ -1385,6 +1527,10 @@ func (s *InstanceState) AttrsAsObjectValue(ty cty.Type) (cty.Value, error) {
 }
 
 // Copy all the Fields from another InstanceState
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *InstanceState) Set(from *InstanceState) {
 	s.Lock()
 	defer s.Unlock()
@@ -1399,6 +1545,9 @@ func (s *InstanceState) Set(from *InstanceState) {
 	s.Tainted = from.Tainted
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *InstanceState) DeepCopy() *InstanceState {
 	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
 	if err != nil {
@@ -1413,6 +1562,9 @@ func (s *InstanceState) DeepCopy() *InstanceState {
 	return instanceState
 }
 
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *InstanceState) Empty() bool {
 	if s == nil {
 		return true
@@ -1492,6 +1644,10 @@ func (s *InstanceState) Equal(other *InstanceState) bool {
 // If the diff attribute requires computing the value, and hence
 // won't be available until apply, the value is replaced with the
 // computeID.
+//
+// Deprecated: This method is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 func (s *InstanceState) MergeDiff(d *InstanceDiff) *InstanceState {
 	result := s.DeepCopy()
 	if result == nil {
@@ -1564,6 +1720,10 @@ func (s *InstanceState) String() string {
 }
 
 // EphemeralState is used for transient state that is only kept in-memory
+//
+// Deprecated: This type is unintentionally exported by this Go module and not
+// supported for external consumption. It will be removed in the next major
+// version.
 type EphemeralState struct {
 	// ConnInfo is used for the providers to export information which is
 	// used to connect to the resource for provisioning. For example,


### PR DESCRIPTION
Closes #165

Except in certain known provider testing use cases without replacement (yet), this deprecates various `terraform` package functionality. The `terraform` package contains legacy Terraform core logic which has been copied to terraform-plugin-sdk and terraform-plugin-testing over the years and continually exported due to the complexity of rewriting developer functionality using the machine-readable interfaces for Terraform, such as JSON state. Much of this now-deprecated `terraform` package logic should have been omitted when this Go module was created, but that step was missed, so it is left as-is with deprecation notices following the Go module versioning guidelines. In reality, the entire `terraform` package will be removed in a future major version, however this change pragmatically leaves certain functionality without deprecation notices for now until  replacement functionality is available so developers will not need to silence linting tools without it being actionable yet.

If there is a valid use case for this functionality, developers should create a GitHub issue for tracking.