### PR TITLE
Fix regression by allowing providers defined at `TestCase` level with providers defined within `TestStep.Config`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230831-171932.yaml
+++ b/.changes/unreleased/BUG FIXES-20230831-171932.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'helper/resource: Fix regression by allowing providers to be defined both at
+  the `TestCase` level, and within `TestStep.Config`'
+time: 2023-08-31T17:19:32.516184+01:00
+custom:
+  Issue: "177"

--- a/helper/resource/teststep_validate.go
+++ b/helper/resource/teststep_validate.go
@@ -64,7 +64,6 @@ func (s TestStep) hasProviders(ctx context.Context, stepIndex int, testName stri
 	configRequest := teststep.PrepareConfigurationRequest{
 		Directory: s.ConfigDirectory,
 		File:      s.ConfigFile,
-		Raw:       s.Config,
 		TestStepConfigRequest: config.TestStepConfigRequest{
 			StepNumber: stepIndex + 1,
 			TestName:   testName,

--- a/helper/resource/teststep_validate_test.go
+++ b/helper/resource/teststep_validate_test.go
@@ -282,6 +282,19 @@ func TestTestStepValidate(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("TestStep ImportState must be specified with ImportStateId, ImportStateIdFunc, or ResourceName"),
 		},
+		// This test has been added to verify that providers can be defined
+		// both within the TestStep.Config and at the TestCase level.
+		// The regression was reported in
+		// https://github.com/hashicorp/terraform-plugin-testing/issues/176
+		"config-providers-testcase-providers": {
+			testStep: TestStep{
+				Config: "provider abc {",
+			},
+			testStepConfig: "# not empty",
+			testStepValidateRequest: testStepValidateRequest{
+				TestCaseHasProviders: true,
+			},
+		},
 		"protov5providerfactories-testcase-providers": {
 			testStep: TestStep{
 				ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){


### PR DESCRIPTION
Closes: #176 

Prior to the changes in this PR, the following test failed:

```go
		"config-providers-testcase-providers": {
			testStep: TestStep{
				Config: "provider abc {",
			},
			testStepConfig: "# not empty",
			testStepValidateRequest: testStepValidateRequest{
				TestCaseHasProviders: true,
			},
		},
```

```shell
=== NAME  TestTestStepValidate/config-providers-testcase-providers
    teststep_validate_test.go:523: unexpected error: Providers must only be specified either at the TestCase or TestStep level
```

Whereas the equivalent test in `v1.4.0` passes:

```go
		"config-providers-testcase-providers": {
			testStep: TestStep{
				Config: "provider abc {",
			},
			testStepValidateRequest: testStepValidateRequest{
				TestCaseHasProviders: true,
			},
		},
```