### PR TITLE
Fix typo in documentation for `-sweep-allow-failures` flag

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -108,7 +108,7 @@ func AddTestSweepers(name string, s *Sweeper) {
 // Sweeper flags added to the "go test" command:
 //
 //	-sweep: Comma-separated list of locations/regions to run available sweepers.
-//	-sweep-allow-failues: Enable to allow other sweepers to run after failures.
+//	-sweep-allow-failures: Enable to allow other sweepers to run after failures.
 //	-sweep-run: Comma-separated list of resource type sweepers to run. Defaults
 //	        to all sweepers.
 //


### PR DESCRIPTION
The documentation specified `-sweep-allow-failues` as one of the flags that could be passed.

This PR corrects the docs to specify `-sweep-allow-failures`.