### PR TITLE
helper/resource: Refresh during plan rather than separately and remove state shimming when possible

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20231122-115402.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20231122-115402.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'helper/resource: Removed separate refresh commands, which increases testing
+  performance'
+time: 2023-11-22T11:54:02.542726-05:00
+custom:
+  Issue: "223"

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -222,10 +222,13 @@ func (wd *WorkingDir) planFilename() string {
 
 // CreatePlan runs "terraform plan" to create a saved plan file, which if successful
 // will then be used for the next call to Apply.
-func (wd *WorkingDir) CreatePlan(ctx context.Context) error {
+func (wd *WorkingDir) CreatePlan(ctx context.Context, opts ...tfexec.PlanOption) error {
 	logging.HelperResourceTrace(ctx, "Calling Terraform CLI plan command")
 
-	hasChanges, err := wd.tf.Plan(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false), tfexec.Out(PlanFileName))
+	opts = append(opts, tfexec.Reattach(wd.reattachInfo))
+	opts = append(opts, tfexec.Out(PlanFileName))
+
+	hasChanges, err := wd.tf.Plan(context.Background(), opts...)
 
 	logging.HelperResourceTrace(ctx, "Called Terraform CLI plan command")
 
@@ -246,36 +249,6 @@ func (wd *WorkingDir) CreatePlan(ctx context.Context) error {
 	}
 
 	logging.HelperResourceTrace(ctx, "Created plan with changes", map[string]any{logging.KeyTestTerraformPlan: stdout})
-
-	return nil
-}
-
-// CreateDestroyPlan runs "terraform plan -destroy" to create a saved plan
-// file, which if successful will then be used for the next call to Apply.
-func (wd *WorkingDir) CreateDestroyPlan(ctx context.Context) error {
-	logging.HelperResourceTrace(ctx, "Calling Terraform CLI plan -destroy command")
-
-	hasChanges, err := wd.tf.Plan(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false), tfexec.Out(PlanFileName), tfexec.Destroy(true))
-
-	logging.HelperResourceTrace(ctx, "Called Terraform CLI plan -destroy command")
-
-	if err != nil {
-		return err
-	}
-
-	if !hasChanges {
-		logging.HelperResourceTrace(ctx, "Created destroy plan with no changes")
-
-		return nil
-	}
-
-	stdout, err := wd.SavedPlanRawStdout(ctx)
-
-	if err != nil {
-		return fmt.Errorf("error retrieving formatted plan output: %w", err)
-	}
-
-	logging.HelperResourceTrace(ctx, "Created destroy plan with changes", map[string]any{logging.KeyTestTerraformPlan: stdout})
 
 	return nil
 }


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/515
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/194
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/222
Reference: https://developer.hashicorp.com/terraform/cli/commands/refresh

This change replaces the usage of explicit refresh commands by instead calling the next command with the relevant refresh flags. Separating the refresh from plan was previously done with the idea that the testing logic may introduce further assertion hooks based on that explicit refresh. Over time though, the Terraform recommendations for refreshing and planning have solidified around always recommending to use a plan with behavior changing flags as necessary. Even the Terraform CLI implementation of the refresh command itself has been shifted to call a plan with special flags.

This should reduce testing times decently as it means that the testing logic will skip spinning up and tearing down any relevant providers two times per `TestStep` and whatever time would be associated with Terraform CLI loading for those commands. Comparing the testing performed across this Go module:

Prior: `TF_ACC=1 go test -count=1 ./...  111.07s user 59.37s system 233% cpu 1:12.99 total`
Now: `TF_ACC=1 go test -count=1 ./...  90.81s user 48.25s system 229% cpu 1:00.54 total`

The separated refresh also prevented `PreApply` plan checks from catching certain situations because the refreshed state could cause the plan to be missing changes.