### PR TITLE
ci: Enable acceptance testing

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -23,20 +23,38 @@ jobs:
       - run: go mod download
       - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
   test:
-    name: test (Go v${{ matrix.go-version }})
+    name: test (Go ${{ matrix.go-version }} / TF ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version: [ '1.21', '1.20' ]
+        terraform-version:
+          - '0.12.*'
+          - '0.13.*'
+          - '0.14.*'
+          - '0.15.*'
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
+          - '1.4.*'
+          - '1.5.*'
+          - '1.6.*'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: ${{ matrix.go-version }}
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        with:
+          terraform_version: ${{ matrix.terraform-version }}
+          terraform_wrapper: false
       - run: go mod download
       - run: go test -coverprofile=coverage.out ./...
+        env:
+          TF_ACC: "1"
       - run: go tool cover -html=coverage.out -o coverage.html
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
-          name: go-${{ matrix.go-version }}-coverage
+          name: go-${{ matrix.go-version }}-terraform-${{ matrix.terraform-version }}-coverage
           path: coverage.html

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -29,17 +29,17 @@ jobs:
       matrix:
         go-version: [ '1.21', '1.20' ]
         terraform-version:
-          - '0.12.*'
-          - '0.13.*'
-          - '0.14.*'
-          - '0.15.*'
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
-          - '1.5.*'
-          - '1.6.*'
+          - '0.12'
+          - '0.13'
+          - '0.14'
+          - '0.15'
+          - '1.0'
+          - '1.1'
+          - '1.2'
+          - '1.3'
+          - '1.4'
+          - '1.5'
+          - '1.6'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
@@ -47,7 +47,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: ${{ matrix.terraform-version }}
+          terraform_version: ${{ matrix.terraform-version }}.*
           terraform_wrapper: false
       - run: go mod download
       - run: go test -coverprofile=coverage.out ./...

--- a/helper/resource/testcase_providers_test.go
+++ b/helper/resource/testcase_providers_test.go
@@ -264,7 +264,7 @@ func TestTest_TestCase_ExternalProviders_NonHashiCorpNamespace(t *testing.T) {
 
 	Test(t, TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ExternalProvider.Source is protocol version 6
 		},
 		ExternalProviders: map[string]ExternalProvider{
 			// This can be set to any provider outside the hashicorp namespace.
@@ -288,7 +288,7 @@ func TestTest_TestCase_ExternalProvidersAndProviderFactories_NonHashiCorpNamespa
 
 	Test(t, TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ExternalProvider.Source is protocol version 6
 		},
 		ExternalProviders: map[string]ExternalProvider{
 			// This can be set to any provider outside the hashicorp namespace.

--- a/helper/resource/testcase_providers_test.go
+++ b/helper/resource/testcase_providers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestTestCaseProviderConfig(t *testing.T) {
@@ -262,6 +263,9 @@ func TestTest_TestCase_ExternalProviders_NonHashiCorpNamespace(t *testing.T) {
 	t.Parallel()
 
 	Test(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+		},
 		ExternalProviders: map[string]ExternalProvider{
 			// This can be set to any provider outside the hashicorp namespace.
 			// bflad/scaffoldingtest happens to be a published version of
@@ -283,6 +287,9 @@ func TestTest_TestCase_ExternalProvidersAndProviderFactories_NonHashiCorpNamespa
 	t.Parallel()
 
 	Test(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+		},
 		ExternalProviders: map[string]ExternalProvider{
 			// This can be set to any provider outside the hashicorp namespace.
 			// bflad/scaffoldingtest happens to be a published version of
@@ -336,6 +343,9 @@ func TestTest_TestCase_ExternalProviders_Error(t *testing.T) {
 
 	plugintest.TestExpectTFatal(t, func() {
 		Test(&mockT{}, TestCase{
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+			},
 			ExternalProviders: map[string]ExternalProvider{
 				"testnonexistent": {
 					Source: "registry.terraform.io/hashicorp/testnonexistent",

--- a/helper/resource/testcase_test.go
+++ b/helper/resource/testcase_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/datasource"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 // Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/84
@@ -19,6 +20,9 @@ func TestTestCase_NoDataSourceIdRequirement(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		Steps: []TestStep{
 			{
 				Check: ComposeAggregateTestCheckFunc(
@@ -69,6 +73,9 @@ func TestTestCase_NoResourceIdRequirement(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		Steps: []TestStep{
 			{
 				Check: ComposeAggregateTestCheckFunc(

--- a/helper/resource/testing_new_config_test.go
+++ b/helper/resource/testing_new_config_test.go
@@ -14,12 +14,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestTest_TestStep_ExpectError_NewConfig(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -67,6 +71,9 @@ func Test_ConfigPlanChecks_PreApply_Called(t *testing.T) {
 	spy1 := &planCheckSpy{}
 	spy2 := &planCheckSpy{}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -133,6 +140,9 @@ func Test_ConfigPlanChecks_PreApply_Errors(t *testing.T) {
 		err: errors.New("spy3 check failed"),
 	}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -188,6 +198,9 @@ func Test_ConfigPlanChecks_PostApplyPreRefresh_Called(t *testing.T) {
 	spy1 := &planCheckSpy{}
 	spy2 := &planCheckSpy{}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -254,6 +267,9 @@ func Test_ConfigPlanChecks_PostApplyPreRefresh_Errors(t *testing.T) {
 		err: errors.New("spy3 check failed"),
 	}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -309,6 +325,9 @@ func Test_ConfigPlanChecks_PostApplyPostRefresh_Called(t *testing.T) {
 	spy1 := &planCheckSpy{}
 	spy2 := &planCheckSpy{}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -375,6 +394,9 @@ func Test_ConfigPlanChecks_PostApplyPostRefresh_Errors(t *testing.T) {
 		err: errors.New("spy3 check failed"),
 	}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{

--- a/helper/resource/testing_new_import_state_test.go
+++ b/helper/resource/testing_new_import_state_test.go
@@ -16,12 +16,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestTest_TestStep_ImportStateCheck_SkipDataSourceState(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
 				DataSources: map[string]testprovider.DataSource{
@@ -122,6 +126,9 @@ func TestTest_TestStep_ImportStateVerify(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -193,6 +200,9 @@ func TestTest_TestStep_ImportStateVerifyIgnore(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -274,6 +284,9 @@ func TestTest_TestStep_ExpectError_ImportState(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{

--- a/helper/resource/testing_new_refresh_state_test.go
+++ b/helper/resource/testing_new_refresh_state_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func Test_RefreshPlanChecks_PostRefresh_Called(t *testing.T) {
@@ -22,6 +23,9 @@ func Test_RefreshPlanChecks_PostRefresh_Called(t *testing.T) {
 	spy1 := &planCheckSpy{}
 	spy2 := &planCheckSpy{}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{
@@ -91,6 +95,9 @@ func Test_RefreshPlanChecks_PostRefresh_Errors(t *testing.T) {
 		err: errors.New("spy3 check failed"),
 	}
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{
 				Resources: map[string]testprovider.Resource{

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -978,7 +978,7 @@ func TestTest_TestStep_ExternalProviders_NonHashiCorpNamespace(t *testing.T) {
 
 	Test(t, TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ExternalProvider.Source is protocol version 6
 		},
 		Steps: []TestStep{
 			{
@@ -1002,7 +1002,7 @@ func TestTest_TestStep_ExternalProvidersAndProviderFactories_NonHashiCorpNamespa
 
 	Test(t, TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ExternalProvider.Source is protocol version 6
 		},
 		Steps: []TestStep{
 			{

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestStepMergedConfig(t *testing.T) {
@@ -976,6 +977,9 @@ func TestTest_TestStep_ExternalProviders_NonHashiCorpNamespace(t *testing.T) {
 	t.Parallel()
 
 	Test(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+		},
 		Steps: []TestStep{
 			{
 				ExternalProviders: map[string]ExternalProvider{
@@ -997,6 +1001,9 @@ func TestTest_TestStep_ExternalProvidersAndProviderFactories_NonHashiCorpNamespa
 	t.Parallel()
 
 	Test(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
+		},
 		Steps: []TestStep{
 			{
 				ExternalProviders: map[string]ExternalProvider{
@@ -1049,6 +1056,9 @@ func TestTest_TestStep_ExternalProviders_To_ProtoV6ProviderFactories(t *testing.
 	t.Parallel()
 
 	Test(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		Steps: []TestStep{
 			{
 				Config: `resource "null_resource" "test" {}`,
@@ -1220,6 +1230,9 @@ func TestTest_TestStep_Taint(t *testing.T) {
 	var idOne, idTwo string
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		Steps: []TestStep{
 			{
 				Config: `resource "test_resource" "test" {}`,
@@ -1405,6 +1418,9 @@ func TestTest_TestStep_ProtoV6ProviderFactories_To_ExternalProviders(t *testing.
 	t.Parallel()
 
 	Test(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		Steps: []TestStep{
 			{
 				Config: `resource "null_resource" "test" {}`,

--- a/helper/resource/teststep_test.go
+++ b/helper/resource/teststep_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 // Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/84
@@ -19,6 +20,9 @@ func TestTestStep_ImportStateVerifyIdentifierAttribute(t *testing.T) {
 	t.Parallel()
 
 	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
 		Steps: []TestStep{
 			{
 				Check: ComposeAggregateTestCheckFunc(
@@ -109,6 +113,9 @@ func TestTestStep_ImportStateVerifyIdentifierAttribute_Error(t *testing.T) {
 
 	plugintest.TestExpectTFatal(t, func() {
 		Test(&mockT{}, TestCase{
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+			},
 			Steps: []TestStep{
 				{
 					Check: ComposeAggregateTestCheckFunc(

--- a/plancheck/expect_sensitive_value_test.go
+++ b/plancheck/expect_sensitive_value_test.go
@@ -14,12 +14,16 @@ import (
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func Test_ExpectSensitiveValue_SensitiveStringAttribute(t *testing.T) {
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil
@@ -47,6 +51,9 @@ func Test_ExpectSensitiveValue_SensitiveListAttribute(t *testing.T) {
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil
@@ -74,6 +81,9 @@ func Test_ExpectSensitiveValue_SensitiveSetAttribute(t *testing.T) {
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil
@@ -101,6 +111,9 @@ func Test_ExpectSensitiveValue_SensitiveMapAttribute(t *testing.T) {
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil
@@ -130,6 +143,9 @@ func Test_ExpectSensitiveValue_ListNestedBlock_SensitiveAttribute(t *testing.T) 
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil
@@ -161,6 +177,9 @@ func Test_ExpectSensitiveValue_SetNestedBlock_SensitiveAttribute(t *testing.T) {
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil
@@ -191,6 +210,9 @@ func Test_ExpectSensitiveValue_ExpectError_ResourceNotFound(t *testing.T) {
 	t.Parallel()
 
 	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // Change.AfterSensitive
+		},
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProviderSensitive(), nil

--- a/tfversion/all_test.go
+++ b/tfversion/all_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_All_RunTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -45,6 +46,7 @@ func Test_All_RunTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_All_SkipTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.0.7")
 
 	r.UnitTest(t, r.TestCase{
@@ -75,6 +77,7 @@ func Test_All_SkipTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_All_Error(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	plugintest.TestExpectTFatal(t, func() {

--- a/tfversion/any_test.go
+++ b/tfversion/any_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_Any_RunTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -42,6 +43,7 @@ func Test_Any_RunTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_Any_SkipTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -68,6 +70,7 @@ func Test_Any_SkipTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_Any_Error(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	plugintest.TestExpectTFatal(t, func() {

--- a/tfversion/require_above_test.go
+++ b/tfversion/require_above_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func Test_RequireAbove(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -41,6 +42,7 @@ func Test_RequireAbove(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_RequireAbove_Error(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.0.7")
 
 	plugintest.TestExpectTFatal(t, func() {

--- a/tfversion/require_below_test.go
+++ b/tfversion/require_below_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func Test_RequireBelow(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -42,6 +43,7 @@ func Test_RequireBelow(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_RequireBelow_Error(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.4.0")
 
 	plugintest.TestExpectTFatal(t, func() {

--- a/tfversion/require_between_test.go
+++ b/tfversion/require_between_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func Test_RequireBetween(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -54,6 +55,7 @@ func Test_RequireBetween(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_RequireBetween_Error_BelowMin(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	plugintest.TestExpectTFatal(t, func() {

--- a/tfversion/require_not_test.go
+++ b/tfversion/require_not_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func Test_RequireNot(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.4.3")
 
 	r.UnitTest(t, r.TestCase{
@@ -37,6 +38,7 @@ func Test_RequireNot(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_RequireNot_Error(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	plugintest.TestExpectTFatal(t, func() {

--- a/tfversion/skip_above_test.go
+++ b/tfversion/skip_above_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_SkipAbove_SkipTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.3.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -39,6 +40,7 @@ func Test_SkipAbove_SkipTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_SkipAbove_RunTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.9")
 
 	r.UnitTest(t, r.TestCase{

--- a/tfversion/skip_below_test.go
+++ b/tfversion/skip_below_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_SkipBelow_SkipTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.0.7")
 
 	r.UnitTest(t, r.TestCase{
@@ -38,6 +39,7 @@ func Test_SkipBelow_SkipTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_SkipBelow_RunTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	r.UnitTest(t, r.TestCase{

--- a/tfversion/skip_between_test.go
+++ b/tfversion/skip_between_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_SkipBetween_SkipTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.0")
 
 	r.UnitTest(t, r.TestCase{
@@ -53,6 +54,7 @@ func Test_SkipBetween_SkipTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_SkipBetween_RunTest_AboveMax(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.3.0")
 
 	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
@@ -73,6 +75,7 @@ func Test_SkipBetween_RunTest_AboveMax(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_SkipBetween_RunTest_EqToMin(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.0")
 
 	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{

--- a/tfversion/skip_if_test.go
+++ b/tfversion/skip_if_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_SkipIf_SkipTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.4.3")
 
 	r.UnitTest(t, r.TestCase{
@@ -36,6 +37,7 @@ func Test_SkipIf_SkipTest(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_SkipIf_RunTest(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
 	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{


### PR DESCRIPTION
This change adds Terraform version matrix testing to the Go code testing workflow and ensures that acceptance testing is enabled, since there are many tests that require the environment variable to run. Unsetting `TF_ACC_TERRAFORM_PATH` is necessary for locally running the tests on other Terraform versions.