### PR TITLE
Skip tests when resource unavailable or entire resource is marked unknown

### DIFF
--- a/plancheck/expect_null_output_value_at_path_test.go
+++ b/plancheck/expect_null_output_value_at_path_test.go
@@ -7,17 +7,26 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func Test_ExpectNullOutputValueAtPath_StringAttribute_EmptyConfig(t *testing.T) {
 	t.Parallel()
 
 	r.Test(t, r.TestCase{
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -46,6 +55,13 @@ func Test_ExpectNullOutputValueAtPath_StringAttribute_NullConfig(t *testing.T) {
 	t.Parallel()
 
 	r.Test(t, r.TestCase{
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -75,6 +91,13 @@ func Test_ExpectNullOutputValueAtPath_StringAttribute_ExpectErrorNotNull(t *test
 	t.Parallel()
 
 	r.Test(t, r.TestCase{
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -110,6 +133,13 @@ func Test_ExpectNullOutputValueAtPath_ListAttribute_EmptyConfig(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "test_resource" "test" {
@@ -137,6 +167,13 @@ func Test_ExpectNullOutputValueAtPath_ListAttribute_NullConfig(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -166,6 +203,13 @@ func Test_ExpectNullOutputValueAtPath_ListAttribute_ExpectErrorNotNull(t *testin
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -197,6 +241,13 @@ func Test_ExpectNullOutputValueAtPath_SetAttribute_EmptyConfig(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "test_resource" "test" {
@@ -224,6 +275,13 @@ func Test_ExpectNullOutputValueAtPath_SetAttribute_NullConfig(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -253,6 +311,13 @@ func Test_ExpectNullOutputValueAtPath_SetAttribute_ExpectErrorNotNull(t *testing
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -284,6 +349,13 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_EmptyConfig(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "test_resource" "test" {
@@ -311,6 +383,13 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_NullConfig(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -340,6 +419,13 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_ExpectErrorNotNull(t *testing
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -374,6 +460,13 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_PartiallyNullConfig_ExpectErr
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "test_resource" "test" {
@@ -407,6 +500,13 @@ func Test_ExpectNullOutputValueAtPath_ListNestedBlock_EmptyConfig(t *testing.T) 
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "test_resource" "test" {
@@ -435,6 +535,13 @@ func Test_ExpectNullOutputValueAtPath_ListNestedBlock_NullConfig(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -467,6 +574,13 @@ func Test_ExpectNullOutputValueAtPath_ListNestedBlock_ExpectErrorNotNull(t *test
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "test_resource" "test" {
@@ -498,6 +612,13 @@ func Test_ExpectNullOutputValueAtPath_SetNestedBlock_NullConfig_ExpectErrorNotNu
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
 		},
 		Steps: []r.TestStep{
 			{

--- a/plancheck/expect_null_output_value_at_path_test.go
+++ b/plancheck/expect_null_output_value_at_path_test.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,7 +24,7 @@ func Test_ExpectNullOutputValueAtPath_StringAttribute_EmptyConfig(t *testing.T) 
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -60,7 +59,7 @@ func Test_ExpectNullOutputValueAtPath_StringAttribute_NullConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -96,7 +95,7 @@ func Test_ExpectNullOutputValueAtPath_StringAttribute_ExpectErrorNotNull(t *test
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -138,7 +137,7 @@ func Test_ExpectNullOutputValueAtPath_ListAttribute_EmptyConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -173,7 +172,7 @@ func Test_ExpectNullOutputValueAtPath_ListAttribute_NullConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -209,7 +208,7 @@ func Test_ExpectNullOutputValueAtPath_ListAttribute_ExpectErrorNotNull(t *testin
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -246,7 +245,7 @@ func Test_ExpectNullOutputValueAtPath_SetAttribute_EmptyConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -281,7 +280,7 @@ func Test_ExpectNullOutputValueAtPath_SetAttribute_NullConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -317,7 +316,7 @@ func Test_ExpectNullOutputValueAtPath_SetAttribute_ExpectErrorNotNull(t *testing
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -354,7 +353,7 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_EmptyConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -389,7 +388,7 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_NullConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -425,7 +424,7 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_ExpectErrorNotNull(t *testing
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -465,7 +464,7 @@ func Test_ExpectNullOutputValueAtPath_MapAttribute_PartiallyNullConfig_ExpectErr
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -505,7 +504,7 @@ func Test_ExpectNullOutputValueAtPath_ListNestedBlock_EmptyConfig(t *testing.T) 
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -541,7 +540,7 @@ func Test_ExpectNullOutputValueAtPath_ListNestedBlock_NullConfig(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -579,7 +578,7 @@ func Test_ExpectNullOutputValueAtPath_ListNestedBlock_ExpectErrorNotNull(t *test
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -618,7 +617,7 @@ func Test_ExpectNullOutputValueAtPath_SetNestedBlock_NullConfig_ExpectErrorNotNu
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{

--- a/plancheck/expect_unknown_output_value_at_path_test.go
+++ b/plancheck/expect_unknown_output_value_at_path_test.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,7 +27,7 @@ func Test_ExpectUnknownOutputValueAtPath_StringAttribute(t *testing.T) {
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -67,7 +66,7 @@ func Test_ExpectUnknownOutputValueAtPath_ListAttribute(t *testing.T) {
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -110,7 +109,7 @@ func Test_ExpectUnknownOutputValueAtPath_SetAttribute(t *testing.T) {
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -153,7 +152,7 @@ func Test_ExpectUnknownOutputValueAtPath_MapAttribute(t *testing.T) {
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -199,7 +198,7 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_Resource(t *testing.T) 
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -244,7 +243,7 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_ResourceBlocks(t *testi
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -289,7 +288,7 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_ObjectBlockIndex(t *tes
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -334,7 +333,7 @@ func Test_ExpectUnknownOutputValueAtPath_SetNestedBlock_Object(t *testing.T) {
 		// The terraform_data resource is not available prior to Terraform v1.4.0
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+			tfversion.SkipBelow(tfversion.Version1_4_0),
 		},
 		Steps: []r.TestStep{
 			{
@@ -376,7 +375,7 @@ func Test_ExpectUnknownOutputValueAtPath_ExpectError_KnownValue(t *testing.T) {
 		// is unknown.
 		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+			tfversion.SkipBelow(tfversion.Version1_3_0),
 		},
 		Steps: []r.TestStep{
 			{

--- a/plancheck/expect_unknown_output_value_at_path_test.go
+++ b/plancheck/expect_unknown_output_value_at_path_test.go
@@ -7,11 +7,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func Test_ExpectUnknownOutputValueAtPath_StringAttribute(t *testing.T) {
@@ -22,6 +24,9 @@ func Test_ExpectUnknownOutputValueAtPath_StringAttribute(t *testing.T) {
 			"data": {
 				Source: "terraform.io/builtin/terraform",
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -56,6 +61,9 @@ func Test_ExpectUnknownOutputValueAtPath_ListAttribute(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -95,6 +103,9 @@ func Test_ExpectUnknownOutputValueAtPath_SetAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "terraform_data" "one" {
@@ -132,6 +143,9 @@ func Test_ExpectUnknownOutputValueAtPath_MapAttribute(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -174,6 +188,9 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_Resource(t *testing.T) 
 				return testProvider(), nil
 			},
 		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "terraform_data" "one" {
@@ -213,6 +230,9 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_ResourceBlocks(t *testi
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -254,6 +274,9 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_ObjectBlockIndex(t *tes
 				return testProvider(), nil
 			},
 		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "terraform_data" "one" {
@@ -293,6 +316,9 @@ func Test_ExpectUnknownOutputValueAtPath_SetNestedBlock_Object(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{

--- a/plancheck/expect_unknown_output_value_at_path_test.go
+++ b/plancheck/expect_unknown_output_value_at_path_test.go
@@ -25,6 +25,8 @@ func Test_ExpectUnknownOutputValueAtPath_StringAttribute(t *testing.T) {
 				Source: "terraform.io/builtin/terraform",
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -62,6 +64,8 @@ func Test_ExpectUnknownOutputValueAtPath_ListAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -103,6 +107,8 @@ func Test_ExpectUnknownOutputValueAtPath_SetAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -144,6 +150,8 @@ func Test_ExpectUnknownOutputValueAtPath_MapAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -188,6 +196,8 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_Resource(t *testing.T) 
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -231,6 +241,8 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_ResourceBlocks(t *testi
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -274,6 +286,8 @@ func Test_ExpectUnknownOutputValueAtPath_ListNestedBlock_ObjectBlockIndex(t *tes
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -317,6 +331,8 @@ func Test_ExpectUnknownOutputValueAtPath_SetNestedBlock_Object(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},

--- a/plancheck/expect_unknown_output_value_at_path_test.go
+++ b/plancheck/expect_unknown_output_value_at_path_test.go
@@ -355,6 +355,13 @@ func Test_ExpectUnknownOutputValueAtPath_ExpectError_KnownValue(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
+		// if any attribute is unknown. The id attribute within the test provider
+		// is unknown.
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `

--- a/plancheck/expect_unknown_output_value_test.go
+++ b/plancheck/expect_unknown_output_value_test.go
@@ -7,10 +7,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func Test_ExpectUnknownOutputValue_StringAttribute(t *testing.T) {
@@ -21,6 +23,9 @@ func Test_ExpectUnknownOutputValue_StringAttribute(t *testing.T) {
 			"data": {
 				Source: "terraform.io/builtin/terraform",
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -55,6 +60,9 @@ func Test_ExpectUnknownOutputValue_ListAttribute(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -94,6 +102,9 @@ func Test_ExpectUnknownOutputValue_SetAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
+		},
 		Steps: []r.TestStep{
 			{
 				Config: `resource "terraform_data" "one" {
@@ -131,6 +142,9 @@ func Test_ExpectUnknownOutputValue_MapAttribute(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{
@@ -172,6 +186,9 @@ func Test_ExpectUnknownOutputValue_ListNestedBlock(t *testing.T) {
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return testProvider(), nil
 			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
 		Steps: []r.TestStep{
 			{

--- a/plancheck/expect_unknown_output_value_test.go
+++ b/plancheck/expect_unknown_output_value_test.go
@@ -24,6 +24,8 @@ func Test_ExpectUnknownOutputValue_StringAttribute(t *testing.T) {
 				Source: "terraform.io/builtin/terraform",
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -61,6 +63,8 @@ func Test_ExpectUnknownOutputValue_ListAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -102,6 +106,8 @@ func Test_ExpectUnknownOutputValue_SetAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -143,6 +149,8 @@ func Test_ExpectUnknownOutputValue_MapAttribute(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},
@@ -187,6 +195,8 @@ func Test_ExpectUnknownOutputValue_ListNestedBlock(t *testing.T) {
 				return testProvider(), nil
 			},
 		},
+		// The terraform_data resource is not available prior to Terraform v1.4.0
+		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
 		},


### PR DESCRIPTION
### Background

Recently, the `terraform-plugin-testing` module was updated to use a matrix of Terraform versions to use when running tests (refer to [ci: Enable acceptance testing](https://github.com/hashicorp/terraform-plugin-testing/pull/224#top)). This has uncovered two issues:

- Tests that use `terraform_data` fail, as the `terraform_data` resource is only available in Terraform `v1.4.0` and later versions (refer to [Enhancements](https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023)).
- Tests that use a path within an output value fail if any attribute value within the resource is unknown, as the entire resource is then marked as unknown in Terraform versions prior to `v1.3.0` (refer to [Upgrade Notes](https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022)).  

### Test Failures

#### Using `terraform_data` when resource is not available

```shell
        Error: Invalid resource type
        
          on terraform_plugin_test.tf line 12, in resource "terraform_data" "one":
          12: resource "terraform_data" "one" {
        
        The provider terraform.io/builtin/terraform does not support resource type
        "terraform_data".
```

#### Using an output value plan check when entire resource is marked unknown

```shell
        path not found: cannot convert object at MapStep string_attribute to map[string]any
```

The following illustrates the difference between Terraform versions < `v1.3.0`, and  >= `v1.3.0`:

##### Terraform prior to `v.1.3.0`

![image](https://github.com/hashicorp/terraform-plugin-testing/assets/4332332/3cfecf23-b68d-438c-b415-d3092fad9329)

##### Terraform `v1.3.0` or later

![image](https://github.com/hashicorp/terraform-plugin-testing/assets/4332332/4d6e6665-efc4-43aa-b10e-ecbe746a499c)
 
### Proposed Fix

#### Use Terraform version checks for `terraform_data`

```go
		// The terraform_data resource is not available prior to Terraform v1.4.0
		// Reference: https://github.com/hashicorp/terraform/blob/v1.4/CHANGELOG.md#140-march-08-2023
		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
			tfversion.SkipBelow(version.Must(version.NewVersion("1.4.0"))),
		},
```

#### Use Terraform version checks for output value

```go
		// Prior to Terraform v1.3.0 a planned output is marked as fully unknown
		// if any attribute is unknown. The id attribute within the test provider
		// is unknown.
		// Reference: https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022
		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
			tfversion.SkipBelow(version.Must(version.NewVersion("1.3.0"))),
		},
```


