### PR TITLE
tfversion: Add variables for version 1.6.0 and 1.7.0

### DIFF
--- a/tfversion/versions.go
+++ b/tfversion/versions.go
@@ -29,4 +29,6 @@ var (
 	Version1_3_0  *version.Version = version.Must(version.NewVersion("1.3.0"))
 	Version1_4_0  *version.Version = version.Must(version.NewVersion("1.4.0"))
 	Version1_5_0  *version.Version = version.Must(version.NewVersion("1.5.0"))
+	Version1_6_0  *version.Version = version.Must(version.NewVersion("1.6.0"))
+	Version1_7_0  *version.Version = version.Must(version.NewVersion("1.7.0"))
 )


### PR DESCRIPTION
Terraform 1.6 already exists and 1.7 is in alpha phase, so it will exist soon enough. This does not feel like it warrants a changelog entry for such as small change, but happy to create one.