### PR TITLE
helper/resource: Ensure TestStep.ExpectNonEmptyPlan accounts for output changes

### DIFF
--- a/.changes/unreleased/BUG FIXES-20231130-102326.yaml
+++ b/.changes/unreleased/BUG FIXES-20231130-102326.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'helper/resource: Ensured `TestStep.ExpectNonEmptyPlan` accounts for output
+  changes with Terraform 0.14 and later'
+time: 2023-11-30T10:23:26.348382-05:00
+custom:
+  Issue: "234"

--- a/.changes/unreleased/NOTES-20231201-160257.yaml
+++ b/.changes/unreleased/NOTES-20231201-160257.yaml
@@ -1,0 +1,10 @@
+kind: NOTES
+body: 'helper/resource: Configuration based `TestStep` now include post-apply plan
+  checks for output changes in addition to resource changes. If this causes
+  unexpected new test failures, most `output` configuration blocks can be likely
+  be removed. Test steps involving resources and data sources should never need
+  to use `output` configuration blocks as plan and state checks support working
+  on resource and data source attributes values directly.'
+time: 2023-12-01T16:02:57.111641-05:00
+custom:
+  Issue: "234"

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/mitchellh/go-testing-interface"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
@@ -24,7 +24,7 @@ import (
 // expectNonEmptyPlanOutputChangesMinTFVersion is used to keep compatibility for
 // Terraform 0.12 and 0.13 after enabling ExpectNonEmptyPlan to check output
 // changes. Those older versions will always show outputs being created.
-var expectNonEmptyPlanOutputChangesMinTFVersion = version.Must(version.NewVersion("0.14.0"))
+var expectNonEmptyPlanOutputChangesMinTFVersion = tfversion.Version0_14_0
 
 func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories, stepIndex int, helper *plugintest.Helper) error {
 	t.Helper()

--- a/helper/resource/testing_new_refresh_state.go
+++ b/helper/resource/testing_new_refresh_state.go
@@ -88,7 +88,7 @@ func testStepNewRefreshState(ctx context.Context, t testing.T, wd *plugintest.Wo
 		}
 	}
 
-	if !planIsEmpty(plan) && !step.ExpectNonEmptyPlan {
+	if !planIsEmpty(plan, wd.GetHelper().TerraformVersion()) && !step.ExpectNonEmptyPlan {
 		var stdout string
 		err = runProviderCommand(ctx, t, func() error {
 			var err error


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/222

This is a followup to similar `plancheck` implementation updates that ensure output changes are checked in the plan in addition to resource changes. The intention of this functionality is to catch any plan differences and has been documented in this manner for a long while.

Since `TestStep.ExpectNonEmptyPlan` pre-dates this Go module, for extra compatibility for developers migrating, output checking is only enabled for Terraform 0.14 and later since prior versions will always show changes when outputs are present in the configuration. Ideally `TestStep.ExpectNonEmptyPlan` will be deprecated in preference of the newer plan checks since its abstraction is fairly ambiguous to when its being invoked, but this deprecation may come by nature of larger changes for a next major version.

New unit test failure prior to implementation update:

```
--- FAIL: Test_ExpectNonEmptyPlan_PostRefresh_OutputChanges (0.42s)
    /Users/bflad/src/github.com/hashicorp/terraform-plugin-testing/helper/resource/testing_new_config_test.go:122: Step 1/1 error: Expected a non-empty plan, but got an empty plan
```
