### PR TITLE
deps: Remove direct dependency on github.com/mitchellh/copystructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.20.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/zclconf/go-cty v1.14.1
@@ -41,6 +40,7 @@ require (
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/run v1.0.0 // indirect

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/reflectwalk"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/configschema"
@@ -177,19 +176,31 @@ func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 		return nil
 	}
 
-	// Copy, this will copy all the exported attributes
-	copiedConfig, err := copystructure.Config{Lock: true}.Copy(c)
-	if err != nil {
-		panic(err)
+	copied := &ResourceConfig{}
+
+	if c.ComputedKeys != nil {
+		copied.ComputedKeys = make([]string, len(c.ComputedKeys))
+
+		copy(copied.ComputedKeys, c.ComputedKeys)
 	}
 
-	// Force the type
-	result, ok := copiedConfig.(*ResourceConfig)
-	if !ok {
-		panic(fmt.Errorf("unexpected type %T for copiedConfig", copiedConfig))
+	if c.Config != nil {
+		copied.Config = make(map[string]any, len(c.Config))
+
+		for key, value := range c.Config {
+			copied.Config[key] = value
+		}
 	}
 
-	return result
+	if c.Raw != nil {
+		copied.Raw = make(map[string]any, len(c.Raw))
+
+		for key, value := range c.Raw {
+			copied.Raw[key] = value
+		}
+	}
+
+	return copied
 }
 
 // Equal checks the equality of two resource configs.

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-uuid"
-	"github.com/mitchellh/copystructure"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim"
@@ -626,17 +625,45 @@ func (s *State) DeepCopy() *State {
 		return nil
 	}
 
-	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
-	if err != nil {
-		panic(err)
+	copied := &State{
+		IsBinaryDrivenTest: s.IsBinaryDrivenTest,
+		Lineage:            s.Lineage,
+		Serial:             s.Serial,
+		TFVersion:          s.TFVersion,
+		Version:            s.Version,
 	}
 
-	state, ok := copiedState.(*State)
-	if !ok {
-		panic(fmt.Errorf("unexpected type %T for copiedState", state))
+	if s.Backend != nil {
+		copied.Backend = &BackendState{
+			Hash:      s.Backend.Hash,
+			ConfigRaw: s.Backend.ConfigRaw,
+			Type:      s.Backend.Type,
+		}
 	}
 
-	return state
+	// Best effort single level copy is fine; this is method is not used by this
+	// Go module and its already deprecated.
+	if s.Modules != nil {
+		copied.Modules = make([]*ModuleState, len(s.Modules))
+
+		copy(copied.Modules, s.Modules)
+	}
+
+	if s.Remote != nil {
+		copied.Remote = &RemoteState{
+			Type: s.Remote.Type,
+		}
+
+		if s.Remote.Config != nil {
+			copied.Remote.Config = make(map[string]string, len(s.Remote.Config))
+
+			for key, value := range s.Remote.Config {
+				copied.Remote.Config[key] = value
+			}
+		}
+	}
+
+	return copied
 }
 
 // Deprecated: This method is unintentionally exported by this Go module and not
@@ -1549,17 +1576,42 @@ func (s *InstanceState) Set(from *InstanceState) {
 // supported for external consumption. It will be removed in the next major
 // version.
 func (s *InstanceState) DeepCopy() *InstanceState {
-	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
-	if err != nil {
-		panic(err)
+	if s == nil {
+		return nil
 	}
 
-	instanceState, ok := copiedState.(*InstanceState)
-	if !ok {
-		panic(fmt.Errorf("unexpected type %T for copiedState", copiedState))
+	copied := &InstanceState{
+		Ephemeral: EphemeralState{
+			ConnInfo: s.Ephemeral.ConnInfo,
+			Type:     s.Ephemeral.Type,
+		},
+		ID:           s.ID,
+		ProviderMeta: s.ProviderMeta,
+		RawConfig:    s.RawConfig,
+		RawPlan:      s.RawPlan,
+		RawState:     s.RawState,
+		Tainted:      s.Tainted,
 	}
 
-	return instanceState
+	if s.Attributes != nil {
+		copied.Attributes = make(map[string]string, len(s.Attributes))
+
+		for k, v := range s.Attributes {
+			copied.Attributes[k] = v
+		}
+	}
+
+	// Best effort single level copy is fine; this is not used by this Go module
+	// and its already deprecated.
+	if s.Meta != nil {
+		copied.Meta = make(map[string]any, len(s.Meta))
+
+		for k, v := range s.Meta {
+			copied.Meta[k] = v
+		}
+	}
+
+	return copied
 }
 
 // Deprecated: This method is unintentionally exported by this Go module and not


### PR DESCRIPTION
Reference: https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc

Its usage was only in esoteric functionality that is unintentionally exported and already deprecated. The `maps`/`slices` Go standard library packages are only Go 1.21+ so could not leverage that immediately since this Go module is 1.20+ until 1.22 is released, but the structures are small enough that its not too much lift to implement the manual copying code.

Remaining indirect dependency is via sdk/v2 (which that dependency will go away next major version anyways):

```
# github.com/mitchellh/copystructure
github.com/hashicorp/terraform-plugin-testing/helper/resource
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
github.com/mitchellh/copystructure
```