### PR TITLE
deps: Remove direct dependency on github.com/mitchellh/reflectwalk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/mitchellh/go-testing-interface v1.14.1
-	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/zclconf/go-cty v1.14.1
 	golang.org/x/crypto v0.17.0
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819
@@ -43,6 +42,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.20.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/zclconf/go-cty v1.14.1
@@ -41,6 +40,7 @@ require (
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/run v1.0.0 // indirect

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/mitchellh/reflectwalk"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim"
@@ -284,12 +283,7 @@ func (c *ResourceConfig) IsComputed(k string) bool {
 	}
 
 	// Test if the value contains an unknown value
-	var w unknownCheckWalker
-	if err := reflectwalk.Walk(v, &w); err != nil {
-		panic(err)
-	}
-
-	return w.Unknown
+	return unknownValueWalk(reflect.ValueOf(v))
 }
 
 func (c *ResourceConfig) get(
@@ -365,19 +359,4 @@ func (c *ResourceConfig) get(
 	}
 
 	return current, true
-}
-
-// unknownCheckWalker
-type unknownCheckWalker struct {
-	Unknown bool
-}
-
-// TODO: investigate why deleting this causes odd runtime test failures
-// must be some kind of interface implementation
-func (w *unknownCheckWalker) Primitive(v reflect.Value) error {
-	if v.Interface() == hcl2shim.UnknownVariableValue {
-		w.Unknown = true
-	}
-
-	return nil
 }

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/reflectwalk"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/configschema"
@@ -177,19 +176,31 @@ func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 		return nil
 	}
 
-	// Copy, this will copy all the exported attributes
-	copiedConfig, err := copystructure.Config{Lock: true}.Copy(c)
-	if err != nil {
-		panic(err)
+	copied := &ResourceConfig{}
+
+	if c.ComputedKeys != nil {
+		copied.ComputedKeys = make([]string, len(c.ComputedKeys))
+
+		copy(copied.ComputedKeys, c.ComputedKeys)
 	}
 
-	// Force the type
-	result, ok := copiedConfig.(*ResourceConfig)
-	if !ok {
-		panic(fmt.Errorf("unexpected type %T for copiedConfig", copiedConfig))
+	if c.Config != nil {
+		copied.Config = make(map[string]any, len(c.Config))
+
+		for key, value := range c.Config {
+			copied.Config[key] = value
+		}
 	}
 
-	return result
+	if c.Raw != nil {
+		copied.Raw = make(map[string]any, len(c.Raw))
+
+		for key, value := range c.Raw {
+			copied.Raw[key] = value
+		}
+	}
+
+	return copied
 }
 
 // Equal checks the equality of two resource configs.

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/mitchellh/reflectwalk"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim"
@@ -278,60 +277,6 @@ func TestResourceConfigEqual_computedKeyOrder(t *testing.T) {
 
 	if !rc.Equal(rc2) {
 		t.Fatal("should be equal")
-	}
-}
-
-func TestUnknownCheckWalker(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		Name   string
-		Input  interface{}
-		Result bool
-	}{
-		{
-			"primitive",
-			42,
-			false,
-		},
-
-		{
-			"primitive computed",
-			hcl2shim.UnknownVariableValue,
-			true,
-		},
-
-		{
-			"list",
-			[]interface{}{"foo", hcl2shim.UnknownVariableValue},
-			true,
-		},
-
-		{
-			"nested list",
-			[]interface{}{
-				"foo",
-				[]interface{}{hcl2shim.UnknownVariableValue},
-			},
-			true,
-		},
-	}
-
-	for i, tc := range cases {
-		i, tc := i, tc
-
-		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			t.Parallel()
-
-			var w unknownCheckWalker
-			if err := reflectwalk.Walk(tc.Input, &w); err != nil {
-				t.Fatalf("err: %s", err)
-			}
-
-			if w.Unknown != tc.Result {
-				t.Fatalf("bad: %v", w.Unknown)
-			}
-		})
 	}
 }
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-uuid"
-	"github.com/mitchellh/copystructure"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim"
@@ -626,17 +625,45 @@ func (s *State) DeepCopy() *State {
 		return nil
 	}
 
-	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
-	if err != nil {
-		panic(err)
+	copied := &State{
+		IsBinaryDrivenTest: s.IsBinaryDrivenTest,
+		Lineage:            s.Lineage,
+		Serial:             s.Serial,
+		TFVersion:          s.TFVersion,
+		Version:            s.Version,
 	}
 
-	state, ok := copiedState.(*State)
-	if !ok {
-		panic(fmt.Errorf("unexpected type %T for copiedState", state))
+	if s.Backend != nil {
+		copied.Backend = &BackendState{
+			Hash:      s.Backend.Hash,
+			ConfigRaw: s.Backend.ConfigRaw,
+			Type:      s.Backend.Type,
+		}
 	}
 
-	return state
+	// Best effort single level copy is fine; this is method is not used by this
+	// Go module and its already deprecated.
+	if s.Modules != nil {
+		copied.Modules = make([]*ModuleState, len(s.Modules))
+
+		copy(copied.Modules, s.Modules)
+	}
+
+	if s.Remote != nil {
+		copied.Remote = &RemoteState{
+			Type: s.Remote.Type,
+		}
+
+		if s.Remote.Config != nil {
+			copied.Remote.Config = make(map[string]string, len(s.Remote.Config))
+
+			for key, value := range s.Remote.Config {
+				copied.Remote.Config[key] = value
+			}
+		}
+	}
+
+	return copied
 }
 
 // Deprecated: This method is unintentionally exported by this Go module and not
@@ -1549,17 +1576,42 @@ func (s *InstanceState) Set(from *InstanceState) {
 // supported for external consumption. It will be removed in the next major
 // version.
 func (s *InstanceState) DeepCopy() *InstanceState {
-	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
-	if err != nil {
-		panic(err)
+	if s == nil {
+		return nil
 	}
 
-	instanceState, ok := copiedState.(*InstanceState)
-	if !ok {
-		panic(fmt.Errorf("unexpected type %T for copiedState", copiedState))
+	copied := &InstanceState{
+		Ephemeral: EphemeralState{
+			ConnInfo: s.Ephemeral.ConnInfo,
+			Type:     s.Ephemeral.Type,
+		},
+		ID:           s.ID,
+		ProviderMeta: s.ProviderMeta,
+		RawConfig:    s.RawConfig,
+		RawPlan:      s.RawPlan,
+		RawState:     s.RawState,
+		Tainted:      s.Tainted,
 	}
 
-	return instanceState
+	if s.Attributes != nil {
+		copied.Attributes = make(map[string]string, len(s.Attributes))
+
+		for k, v := range s.Attributes {
+			copied.Attributes[k] = v
+		}
+	}
+
+	// Best effort single level copy is fine; this is not used by this Go module
+	// and its already deprecated.
+	if s.Meta != nil {
+		copied.Meta = make(map[string]any, len(s.Meta))
+
+		for k, v := range s.Meta {
+			copied.Meta[k] = v
+		}
+	}
+
+	return copied
 }
 
 // Deprecated: This method is unintentionally exported by this Go module and not

--- a/terraform/unknown_value_walk.go
+++ b/terraform/unknown_value_walk.go
@@ -1,0 +1,85 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package terraform
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim"
+)
+
+// unknownValueWalk is a reimplementation of the prior walk() logic from
+// github.com/mitchellh/reflectwalk and the only walker implemented in this
+// module that checked values for hcl2shim.UnknownVariableValue.
+//
+// Using reflection instead of known logic here is a Go anti-pattern, however
+// this logic will be removed in the next major version, so the reflection
+// approach is preserved to minimize reimplementation effort.
+func unknownValueWalk(v reflect.Value) bool {
+	for {
+		switch v.Kind() {
+		case reflect.Interface:
+			v = v.Elem()
+
+			continue
+		case reflect.Pointer:
+			v = reflect.Indirect(v)
+
+			continue
+		}
+
+		break
+	}
+
+	switch v.Kind() {
+	case reflect.Bool,
+		reflect.Complex128,
+		reflect.Complex64,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Int,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Int8,
+		reflect.Uint,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uint8,
+		reflect.Uintptr,
+		reflect.String:
+		value := v.Interface()
+
+		return value == hcl2shim.UnknownVariableValue
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			value := v.MapIndex(k)
+
+			if foundUnknown := unknownValueWalk(value); foundUnknown {
+				return true
+			}
+		}
+	case reflect.Array, reflect.Slice:
+		for index := 0; index < v.Len(); index++ {
+			value := v.Index(index)
+
+			if foundUnknown := unknownValueWalk(value); foundUnknown {
+				return true
+			}
+		}
+	case reflect.Struct:
+		for index := 0; index < v.Type().NumField(); index++ {
+			value := v.FieldByIndex([]int{index})
+
+			if foundUnknown := unknownValueWalk(value); foundUnknown {
+				return true
+			}
+		}
+	default:
+		panic("unsupported reflect type: " + v.Kind().String())
+	}
+
+	return false
+}

--- a/terraform/unknown_value_walk_test.go
+++ b/terraform/unknown_value_walk_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package terraform
 
 import (

--- a/terraform/unknown_value_walk_test.go
+++ b/terraform/unknown_value_walk_test.go
@@ -1,0 +1,68 @@
+package terraform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim"
+)
+
+func TestUnknownValueWalk(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		value    any
+		expected bool
+	}{
+		"primitive": {
+			value:    42,
+			expected: false,
+		},
+		"primitive computed": {
+			value:    hcl2shim.UnknownVariableValue,
+			expected: true,
+		},
+		"list": {
+			value: []any{
+				"foo",
+				hcl2shim.UnknownVariableValue,
+			},
+			expected: true,
+		},
+		"nested list": {
+			value: []any{
+				"foo",
+				[]any{hcl2shim.UnknownVariableValue},
+			},
+			expected: true,
+		},
+		"map": {
+			value: map[string]any{
+				"testkey1": "foo",
+				"testkey2": hcl2shim.UnknownVariableValue,
+			},
+			expected: true,
+		},
+		"nested map": {
+			value: map[string]any{
+				"testkey1": "foo",
+				"testkey2": map[string]any{"testkey": hcl2shim.UnknownVariableValue},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := unknownValueWalk(reflect.ValueOf(testCase.value))
+
+			if got != testCase.expected {
+				t.Errorf("expected: %t, got: %t", testCase.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc

Its usage was only in esoteric functionality that is unintentionally exported and already deprecated.

Remaining indirect dependency is via sdk/v2 (which that dependency will go away next major version):

```
# github.com/mitchellh/reflectwalk
github.com/hashicorp/terraform-plugin-testing/helper/resource
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
github.com/hashicorp/terraform-plugin-sdk/v2/terraform
github.com/mitchellh/reflectwalk
```