### PR TITLE
deps: Remove golang.org/x/exp dependency

### DIFF
--- a/config/constraints.go
+++ b/config/constraints.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+// anyFloat is a constraint that permits any floating-point type. This type
+// definition is copied rather than depending on x/exp/constraints since the
+// dependency is otherwise unneeded, the definition is relatively trivial and
+// static, and the Go language maintainers are not sure if/where these will live
+// in the standard library.
+//
+// Reference: https://github.com/golang/go/issues/61914
+type anyFloat interface {
+	~float32 | ~float64
+}
+
+// anyInteger is a constraint that permits any integer type. This type
+// definition is copied rather than depending on x/exp/constraints since the
+// dependency is otherwise unneeded, the definition is relatively trivial and
+// static, and the Go language maintainers are not sure if/where these will live
+// in the standard library.
+//
+// Reference: https://github.com/golang/go/issues/61914
+type anyInteger interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/config/variable.go
+++ b/config/variable.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-
-	"golang.org/x/exp/constraints"
 )
 
 const autoTFVarsJson = "terraform-plugin-testing.auto.tfvars.json"
@@ -81,7 +79,7 @@ func (v floatVariable) MarshalJSON() ([]byte, error) {
 }
 
 // FloatVariable returns floatVariable which implements Variable.
-func FloatVariable[T constraints.Float](value T) floatVariable {
+func FloatVariable[T anyFloat](value T) floatVariable {
 	return floatVariable{
 		value: value,
 	}
@@ -100,7 +98,7 @@ func (v integerVariable) MarshalJSON() ([]byte, error) {
 }
 
 // IntegerVariable returns integerVariable which implements Variable.
-func IntegerVariable[T constraints.Integer](value T) integerVariable {
+func IntegerVariable[T anyInteger](value T) integerVariable {
 	return integerVariable{
 		value: value,
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/zclconf/go-cty v1.14.1
 	golang.org/x/crypto v0.17.0
-	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2Uz
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 h1:EDuYyU/MkFXllv9QF9819VlI9a4tzGuCbhG0ExK9o1U=
-golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=


### PR DESCRIPTION
Reference: https://github.com/golang/go/issues/61914

It was only used for the `constraints` package, the type definitions are relatively trivial and static, and the Go language maintainers are not sure if/where these will live in the standard library, which implies (at least to me) they could also disappear from x/exp.