### PR TITLE
website: Mention PlanOnly to ConfigPlanChecks in migration guide

### DIFF
--- a/website/docs/plugin/testing/migrating.mdx
+++ b/website/docs/plugin/testing/migrating.mdx
@@ -24,6 +24,26 @@ Change all instances of the following Go import statements in `*_test.go` files:
 
 If the provider implements terraform-plugin-sdk based state migration unit testing with `github.com/hashicorp/terraform-plugin-sdk/v2/terraform.InstanceState`, this must remain with the original import since it is testing terraform-plugin-sdk functionality.
 
+Verify if the `TestStep` type `PlanOnly` field is enabled in any tests where the final `TestStep` is intentionally changing the provider setup to ensure schema changes (e.g. state upgrades or SDK to framework migrations) cause no plan differences. In those tests, replace `PlanOnly` with `ConfigPlanChecks` containing a `PreApply` check of `plancheck.ExpectEmptyPlan()` instead:
+
+```go
+resource.Test(t, resource.TestCase{
+    // ...
+    Steps: []resource.TestStep{
+        { /* ... */ },
+        {
+            // ...
+            // The below replacing PlanOnly: true
+            ConfigPlanChecks: resource.ConfigPlanChecks{
+                PreApply: []plancheck.PlanCheck{
+                    plancheck.ExpectEmptyPlan(),
+                },
+            },
+        },
+    },
+})
+```
+
 Change all instances of the following in **non-test** `*.go` files:
 
 | Original Reference | Migrated Reference |
@@ -81,3 +101,33 @@ github.com/hashicorp/terraform-plugin-testing/helper/resource.init()
 ```
 
 Remove imports of `github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource` to resolve the issue. terraform-plugin-sdk version 2.26.0 introduced separate packages, [`github.com/hashicorp/terraform-plugin-sdk/v2/helper/id`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/id) and [`github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry), which contain all non-testing functionality.
+
+### Failed to marshal state to json
+
+This error can occur when your testing includes `PlanOnly: true` in final `TestStep` that is intentionally changing the provider setup to ensure schema changes (e.g. state upgrades or SDK to framework migrations) cause no plan differences:
+
+```text
+Failed to marshal state to json: schema version 0 for examplecloud_thing.test in state does not match version 1 from the provider
+# or in the case of removed attributes between provider versions:
+Failed to marshal state to json: unsupported attribute
+```
+
+In those tests, replace `PlanOnly` with `ConfigPlanChecks` containing a `PreApply` check of `plancheck.ExpectEmptyPlan()` instead:
+
+```go
+resource.Test(t, resource.TestCase{
+    // ...
+    Steps: []resource.TestStep{
+        { /* ... at least one prior step ... */ },
+        {
+            // ...
+            // Replacing PlanOnly: true
+            ConfigPlanChecks: resource.ConfigPlanChecks{
+                PreApply: []plancheck.PlanCheck{
+                    plancheck.ExpectEmptyPlan(),
+                },
+            },
+        },
+    },
+})
+```


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/237
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/256

Technically, this testing change is always safe to make, but this calls out the currently known situations it will cause errors to not over-burden developers during their migration.