### PR TITLE
tfversion: Add variable for version 1.8.0

### DIFF
--- a/tfversion/versions.go
+++ b/tfversion/versions.go
@@ -31,4 +31,5 @@ var (
 	Version1_5_0  *version.Version = version.Must(version.NewVersion("1.5.0"))
 	Version1_6_0  *version.Version = version.Must(version.NewVersion("1.6.0"))
 	Version1_7_0  *version.Version = version.Must(version.NewVersion("1.7.0"))
+	Version1_8_0  *version.Version = version.Must(version.NewVersion("1.8.0"))
 )


### PR DESCRIPTION
Terraform 1.7 is now generally available and we know there will be 1.8 for provider functions, etc. This does not feel like it warrants a changelog entry for such as small change, but happy to create one.