### PR TITLE
Add calls to `t.Helper()` in `defer`ed functions

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240229-095804.yaml
+++ b/.changes/unreleased/BUG FIXES-20240229-095804.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'helper/resource: Fixed internal deferred test helpers to properly report file
+  and line information in test failures.'
+time: 2024-02-29T09:58:04.443444-05:00
+custom:
+  Issue: "292"

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -63,6 +63,8 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 	}
 
 	defer func() {
+		t.Helper()
+
 		var statePreDestroy *terraform.State
 		var err error
 		err = runProviderCommand(ctx, t, func() error {
@@ -558,6 +560,8 @@ func testIDRefresh(ctx context.Context, t testing.T, c TestCase, wd *plugintest.
 	}
 
 	defer func() {
+		t.Helper()
+
 		confRequest := teststep.PrepareConfigurationRequest{
 			Directory: step.ConfigDirectory,
 			File:      step.ConfigFile,


### PR DESCRIPTION
Adds missing calls to `t.Helper()` in two `defer`ed functions.

Closes https://github.com/hashicorp/terraform-plugin-testing/issues/292.

```console
% go test ./...
?   	github.com/hashicorp/terraform-plugin-testing/helper/logging	[no test files]
ok  	github.com/hashicorp/terraform-plugin-testing/config	2.009s
ok  	github.com/hashicorp/terraform-plugin-testing/helper/acctest	2.362s
?   	github.com/hashicorp/terraform-plugin-testing/internal/addrs	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/datasource	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/provider	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver	[no test files]
?   	github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource	[no test files]
ok  	github.com/hashicorp/terraform-plugin-testing/helper/resource	95.516s
ok  	github.com/hashicorp/terraform-plugin-testing/internal/configs/configschema	0.644s
ok  	github.com/hashicorp/terraform-plugin-testing/internal/configs/hcl2shim	2.394s
ok  	github.com/hashicorp/terraform-plugin-testing/internal/logging	0.924s
ok  	github.com/hashicorp/terraform-plugin-testing/internal/plugintest	10.395s
ok  	github.com/hashicorp/terraform-plugin-testing/internal/teststep	1.521s
ok  	github.com/hashicorp/terraform-plugin-testing/internal/tfdiags	1.910s
ok  	github.com/hashicorp/terraform-plugin-testing/knownvalue	2.024s
ok  	github.com/hashicorp/terraform-plugin-testing/plancheck	8.467s
ok  	github.com/hashicorp/terraform-plugin-testing/statecheck	5.476s
ok  	github.com/hashicorp/terraform-plugin-testing/terraform	4.563s
ok  	github.com/hashicorp/terraform-plugin-testing/tfjsonpath	4.606s
ok  	github.com/hashicorp/terraform-plugin-testing/tfversion	129.643s
```