### PR TITLE
tfversion: Add variable for version 1.9.0

### DIFF
--- a/tfversion/versions.go
+++ b/tfversion/versions.go
@@ -35,4 +35,5 @@ var (
 	Version1_6_0 *version.Version = version.Must(version.NewVersion("1.6.0"))
 	Version1_7_0 *version.Version = version.Must(version.NewVersion("1.7.0"))
 	Version1_8_0 *version.Version = version.Must(version.NewVersion("1.8.0"))
+	Version1_9_0 *version.Version = version.Must(version.NewVersion("1.9.0"))
 )


### PR DESCRIPTION
Terraform 1.8.0-beta1 has been released and a 1.9 release branch has already been cut with its own changelog entries so we know there will be 1.9 series. As with any of these `tfversion` version variable inclusions, it does not feel like it warrants a changelog entry for such as small change, but happy to create one.