### PR TITLE
internal/testingiface: New testing.T equivalent interface and unit testing helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/zclconf/go-cty v1.14.3
 	golang.org/x/crypto v0.21.0
 )
@@ -41,6 +40,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 
 	"github.com/hashicorp/logutils"
-	"github.com/mitchellh/go-testing-interface"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 )
 
 // These are the environmental variables that determine if we log, and if
@@ -33,7 +33,7 @@ var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 // logging controlled by Terraform itself and managed with the TF_ACC_LOG_PATH
 // environment variable. Calls to tflog.* will have their output managed by the
 // tfsdklog sink.
-func LogOutput(t testing.T) (logOutput io.Writer, err error) {
+func LogOutput(t testingiface.T) (logOutput io.Writer, err error) {
 	logOutput = io.Discard
 
 	logLevel := LogLevel()
@@ -91,7 +91,7 @@ func LogOutput(t testing.T) (logOutput io.Writer, err error) {
 // SetOutput checks for a log destination with LogOutput, and calls
 // log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
 // io.Discard. Any error from LogOutout is fatal.
-func SetOutput(t testing.T) {
+func SetOutput(t testingiface.T) {
 	out, err := LogOutput(t)
 	if err != nil {
 		log.Fatal(err)

--- a/helper/resource/plan_checks.go
+++ b/helper/resource/plan_checks.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 
 	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/mitchellh/go-testing-interface"
 )
 
-func runPlanChecks(ctx context.Context, t testing.T, plan *tfjson.Plan, planChecks []plancheck.PlanCheck) error {
+func runPlanChecks(ctx context.Context, t testingiface.T, plan *tfjson.Plan, planChecks []plancheck.PlanCheck) error {
 	t.Helper()
 
 	var result []error

--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -17,10 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 )
 
 // protov5ProviderFactory is a function which is called to start a protocol
@@ -113,7 +113,7 @@ type providerFactories struct {
 	protov6 protov6ProviderFactories
 }
 
-func runProviderCommand(ctx context.Context, t testing.T, f func() error, wd *plugintest.WorkingDir, factories *providerFactories) error {
+func runProviderCommand(ctx context.Context, t testingiface.T, f func() error, wd *plugintest.WorkingDir, factories *providerFactories) error {
 	// don't point to this as a test failure location
 	// point to whatever called it
 	t.Helper()

--- a/helper/resource/state_checks.go
+++ b/helper/resource/state_checks.go
@@ -8,12 +8,12 @@ import (
 	"errors"
 
 	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/mitchellh/go-testing-interface"
 
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 )
 
-func runStateChecks(ctx context.Context, t testing.T, state *tfjson.State, stateChecks []statecheck.StateCheck) error {
+func runStateChecks(ctx context.Context, t testingiface.T, state *tfjson.State, stateChecks []statecheck.StateCheck) error {
 	t.Helper()
 
 	var result []error

--- a/helper/resource/testcase_providers_test.go
+++ b/helper/resource/testcase_providers_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -344,8 +344,8 @@ func TestTest_TestCase_ExternalProvidersAndProviderFactories_NonHashiCorpNamespa
 func TestTest_TestCase_ExternalProviders_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		Test(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		Test(mockT, TestCase{
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.SkipBelow(tfversion.Version0_13_0), // ExternalProvider.Source
 			},
@@ -366,7 +366,7 @@ func TestTest_TestCase_ExternalProviders_Error(t *testing.T) {
 func TestTest_TestCase_ProtoV5ProviderFactories(t *testing.T) {
 	t.Parallel()
 
-	Test(&mockT{}, TestCase{
+	Test(t, TestCase{
 		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
 			"test": providerserver.NewProtov5ProviderServer(testprovider.Protov5Provider{}),
 		},
@@ -381,8 +381,8 @@ func TestTest_TestCase_ProtoV5ProviderFactories(t *testing.T) {
 func TestTest_TestCase_ProtoV5ProviderFactories_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		Test(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		Test(mockT, TestCase{
 			ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
 				"test": func() (tfprotov5.ProviderServer, error) { //nolint:unparam // required signature
 					return nil, fmt.Errorf("test")
@@ -400,7 +400,7 @@ func TestTest_TestCase_ProtoV5ProviderFactories_Error(t *testing.T) {
 func TestTest_TestCase_ProtoV6ProviderFactories(t *testing.T) {
 	t.Parallel()
 
-	Test(&mockT{}, TestCase{
+	Test(t, TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"test": providerserver.NewProviderServer(testprovider.Provider{}),
 		},
@@ -415,8 +415,8 @@ func TestTest_TestCase_ProtoV6ProviderFactories(t *testing.T) {
 func TestTest_TestCase_ProtoV6ProviderFactories_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		Test(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		Test(mockT, TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
 					return nil, fmt.Errorf("test")
@@ -434,7 +434,7 @@ func TestTest_TestCase_ProtoV6ProviderFactories_Error(t *testing.T) {
 func TestTest_TestCase_ProviderFactories(t *testing.T) {
 	t.Parallel()
 
-	Test(&mockT{}, TestCase{
+	Test(t, TestCase{
 		ProviderFactories: map[string]func() (*schema.Provider, error){
 			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 				return &schema.Provider{}, nil
@@ -451,8 +451,8 @@ func TestTest_TestCase_ProviderFactories(t *testing.T) {
 func TestTest_TestCase_ProviderFactories_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		Test(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		Test(mockT, TestCase{
 			ProviderFactories: map[string]func() (*schema.Provider, error){
 				"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
 					return nil, fmt.Errorf("test")
@@ -470,7 +470,7 @@ func TestTest_TestCase_ProviderFactories_Error(t *testing.T) {
 func TestTest_TestCase_Providers(t *testing.T) {
 	t.Parallel()
 
-	Test(&mockT{}, TestCase{
+	Test(t, TestCase{
 		Providers: map[string]*schema.Provider{
 			"test": {},
 		},

--- a/helper/resource/testcase_validate.go
+++ b/helper/resource/testcase_validate.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mitchellh/go-testing-interface"
-
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 )
 
@@ -51,7 +50,7 @@ func (c TestCase) hasProviders(_ context.Context) bool {
 //   - No overlapping ExternalProviders and Providers entries
 //   - No overlapping ExternalProviders and ProviderFactories entries
 //   - TestStep validations performed by the (TestStep).validate() method.
-func (c TestCase) validate(ctx context.Context, t testing.T) error {
+func (c TestCase) validate(ctx context.Context, t testingiface.T) error {
 	logging.HelperResourceTrace(ctx, "Validating TestCase")
 
 	if len(c.Steps) == 0 {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/go-testing-interface"
-
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
@@ -31,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 )
 
 // flagSweep is a flag available when running tests on the command line. It
@@ -808,7 +807,7 @@ type RefreshPlanChecks struct {
 // tests to occur against the same resource or service (e.g. random naming).
 //
 // Test() function requirements and documentation also apply to this function.
-func ParallelTest(t testing.T, c TestCase) {
+func ParallelTest(t testingiface.T, c TestCase) {
 	t.Helper()
 	t.Parallel()
 	Test(t, c)
@@ -845,7 +844,7 @@ func ParallelTest(t testing.T, c TestCase) {
 //
 // Refer to the Env prefixed constants for additional details about these
 // environment variables, and others, that control testing functionality.
-func Test(t testing.T, c TestCase) {
+func Test(t testingiface.T, c TestCase) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -929,7 +928,7 @@ func Test(t testing.T, c TestCase) {
 // have any external dependencies.
 //
 // Test() function requirements and documentation also apply to this function.
-func UnitTest(t testing.T, c TestCase) {
+func UnitTest(t testingiface.T, c TestCase) {
 	t.Helper()
 
 	c.IsUnitTest = true

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -15,16 +15,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func runPostTestDestroy(ctx context.Context, t testing.T, c TestCase, wd *plugintest.WorkingDir, providers *providerFactories, statePreDestroy *terraform.State) error {
+func runPostTestDestroy(ctx context.Context, t testingiface.T, c TestCase, wd *plugintest.WorkingDir, providers *providerFactories, statePreDestroy *terraform.State) error {
 	t.Helper()
 
 	err := runProviderCommand(ctx, t, func() error {
@@ -48,7 +48,7 @@ func runPostTestDestroy(ctx context.Context, t testing.T, c TestCase, wd *plugin
 	return nil
 }
 
-func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest.Helper) {
+func runNewTest(ctx context.Context, t testingiface.T, c TestCase, helper *plugintest.Helper) {
 	t.Helper()
 
 	wd := helper.RequireNewWorkingDir(ctx, t, c.WorkingDir)
@@ -461,7 +461,7 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 	}
 }
 
-func getState(ctx context.Context, t testing.T, wd *plugintest.WorkingDir) (*terraform.State, error) {
+func getState(ctx context.Context, t testingiface.T, wd *plugintest.WorkingDir) (*terraform.State, error) {
 	t.Helper()
 
 	jsonState, err := wd.State(ctx)
@@ -501,7 +501,7 @@ func planIsEmpty(plan *tfjson.Plan, tfVersion *version.Version) bool {
 	return true
 }
 
-func testIDRefresh(ctx context.Context, t testing.T, c TestCase, wd *plugintest.WorkingDir, step TestStep, r *terraform.ResourceState, providers *providerFactories, stepIndex int, helper *plugintest.Helper) error {
+func testIDRefresh(ctx context.Context, t testingiface.T, c TestCase, wd *plugintest.WorkingDir, step TestStep, r *terraform.ResourceState, providers *providerFactories, stepIndex int, helper *plugintest.Helper) error {
 	t.Helper()
 
 	// Build the state. The state is just the resource with an ID. There
@@ -643,7 +643,7 @@ func testIDRefresh(ctx context.Context, t testing.T, c TestCase, wd *plugintest.
 	return nil
 }
 
-func copyWorkingDir(ctx context.Context, t testing.T, stepNumber int, wd *plugintest.WorkingDir) {
+func copyWorkingDir(ctx context.Context, t testingiface.T, stepNumber int, wd *plugintest.WorkingDir) {
 	if os.Getenv(plugintest.EnvTfAccPersistWorkingDir) == "" {
 		return
 	}

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -26,7 +26,7 @@ import (
 // changes. Those older versions will always show outputs being created.
 var expectNonEmptyPlanOutputChangesMinTFVersion = tfversion.Version0_14_0
 
-func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories, stepIndex int, helper *plugintest.Helper) error {
+func testStepNewConfig(ctx context.Context, t testingiface.T, c TestCase, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories, stepIndex int, helper *plugintest.Helper) error {
 	t.Helper()
 
 	configRequest := teststep.PrepareConfigurationRequest{

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 )
 
-func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest.Helper, wd *plugintest.WorkingDir, step TestStep, cfg teststep.Config, providers *providerFactories, stepIndex int) error {
+func testStepNewImportState(ctx context.Context, t testingiface.T, helper *plugintest.Helper, wd *plugintest.WorkingDir, step TestStep, cfg teststep.Config, providers *providerFactories, stepIndex int) error {
 	t.Helper()
 
 	configRequest := teststep.PrepareConfigurationRequest{

--- a/helper/resource/testing_new_refresh_state.go
+++ b/helper/resource/testing_new_refresh_state.go
@@ -8,15 +8,15 @@ import (
 	"fmt"
 
 	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 )
 
-func testStepNewRefreshState(ctx context.Context, t testing.T, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories) error {
+func testStepNewRefreshState(ctx context.Context, t testingiface.T, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories) error {
 	t.Helper()
 
 	var err error

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	testinginterface "github.com/mitchellh/go-testing-interface"
 
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -28,25 +28,21 @@ func init() {
 func TestParallelTest(t *testing.T) {
 	t.Parallel()
 
-	mt := new(mockT)
-
-	ParallelTest(mt, TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
-				return &schema.Provider{}, nil
+	testingiface.ExpectParallel(t, func(mockT *testingiface.MockT) {
+		ParallelTest(mockT, TestCase{
+			IsUnitTest: true,
+			ProviderFactories: map[string]func() (*schema.Provider, error){
+				"test": func() (*schema.Provider, error) { //nolint:unparam // required signature
+					return &schema.Provider{}, nil
+				},
 			},
-		},
-		Steps: []TestStep{
-			{
-				Config: "# not empty",
+			Steps: []TestStep{
+				{
+					Config: "# not empty",
+				},
 			},
-		},
+		})
 	})
-
-	if !mt.ParallelCalled {
-		t.Fatal("Parallel() not called")
-	}
 }
 
 func TestComposeAggregateTestCheckFunc(t *testing.T) {
@@ -129,21 +125,6 @@ func TestComposeTestCheckFunc(t *testing.T) {
 			t.Fatalf("Case %d bad: %s", i, err)
 		}
 	}
-}
-
-// mockT implements TestT for testing
-type mockT struct {
-	testinginterface.RuntimeT
-
-	ParallelCalled bool
-}
-
-func (t *mockT) Parallel() {
-	t.ParallelCalled = true
-}
-
-func (t *mockT) Name() string {
-	return "MockedName"
 }
 
 func TestTest_Main(t *testing.T) {

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -1946,8 +1947,8 @@ func TestTest_TestStep_ExternalProviders_DifferentVersions(t *testing.T) {
 func TestTest_TestStep_ExternalProviders_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		Test(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		Test(mockT, TestCase{
 			Steps: []TestStep{
 				{
 					Config: "# not empty",
@@ -2334,7 +2335,7 @@ func extractResourceAttr(resourceName string, attributeName string, attributeVal
 func TestTest_TestStep_ProtoV5ProviderFactories(t *testing.T) {
 	t.Parallel()
 
-	UnitTest(&mockT{}, TestCase{
+	UnitTest(t, TestCase{
 		Steps: []TestStep{
 			{
 				Config: "# not empty",
@@ -2349,8 +2350,8 @@ func TestTest_TestStep_ProtoV5ProviderFactories(t *testing.T) {
 func TestTest_TestStep_ProtoV5ProviderFactories_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		UnitTest(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		UnitTest(mockT, TestCase{
 			Steps: []TestStep{
 				{
 					Config: "# not empty",
@@ -2368,7 +2369,7 @@ func TestTest_TestStep_ProtoV5ProviderFactories_Error(t *testing.T) {
 func TestTest_TestStep_ProtoV6ProviderFactories(t *testing.T) {
 	t.Parallel()
 
-	UnitTest(&mockT{}, TestCase{
+	UnitTest(t, TestCase{
 		Steps: []TestStep{
 			{
 				Config: "# not empty",
@@ -2383,8 +2384,8 @@ func TestTest_TestStep_ProtoV6ProviderFactories(t *testing.T) {
 func TestTest_TestStep_ProtoV6ProviderFactories_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		UnitTest(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		UnitTest(mockT, TestCase{
 			Steps: []TestStep{
 				{
 					Config: "# not empty",
@@ -2465,7 +2466,7 @@ func TestTest_TestStep_ProtoV6ProviderFactories_To_ExternalProviders(t *testing.
 func TestTest_TestStep_ProviderFactories(t *testing.T) {
 	t.Parallel()
 
-	UnitTest(&mockT{}, TestCase{
+	UnitTest(t, TestCase{
 		Steps: []TestStep{
 			{
 				Config: "# not empty",
@@ -2482,8 +2483,8 @@ func TestTest_TestStep_ProviderFactories(t *testing.T) {
 func TestTest_TestStep_ProviderFactories_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		UnitTest(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		UnitTest(mockT, TestCase{
 			Steps: []TestStep{
 				{
 					Config: "# not empty",

--- a/helper/resource/teststep_test.go
+++ b/helper/resource/teststep_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -111,8 +111,8 @@ func TestTestStep_ImportStateVerifyIdentifierAttribute(t *testing.T) {
 func TestTestStep_ImportStateVerifyIdentifierAttribute_Error(t *testing.T) {
 	t.Parallel()
 
-	plugintest.TestExpectTFatal(t, func() {
-		Test(&mockT{}, TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		Test(mockT, TestCase{
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
 			},

--- a/helper/resource/tfversion_checks.go
+++ b/helper/resource/tfversion_checks.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-version"
-	"github.com/mitchellh/go-testing-interface"
 
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
-func runTFVersionChecks(ctx context.Context, t testing.T, terraformVersion *version.Version, terraformVersionChecks []tfversion.TerraformVersionCheck) {
+func runTFVersionChecks(ctx context.Context, t testingiface.T, terraformVersion *version.Version, terraformVersionChecks []tfversion.TerraformVersionCheck) {
 	t.Helper()
 
 	for _, tfVersionCheck := range terraformVersionChecks {

--- a/helper/resource/tfversion_checks_test.go
+++ b/helper/resource/tfversion_checks_test.go
@@ -9,10 +9,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func TestRunTFVersionChecks(t *testing.T) {
@@ -54,8 +52,8 @@ func TestRunTFVersionChecks(t *testing.T) {
 			t.Parallel()
 
 			if test.expectError {
-				plugintest.TestExpectTFatal(t, func() {
-					runTFVersionChecks(context.Background(), &testinginterface.RuntimeT{}, test.tfVersion, test.versionChecks)
+				testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+					runTFVersionChecks(context.Background(), mockT, test.tfVersion, test.versionChecks)
 				})
 			} else {
 				runTFVersionChecks(context.Background(), t, test.tfVersion, test.versionChecks)

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	helperlogging "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
-	testing "github.com/mitchellh/go-testing-interface"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 )
 
 // InitContext creates SDK logger contexts when the provider is running in
@@ -34,7 +34,7 @@ func InitContext(ctx context.Context) context.Context {
 // The standard library log package handling is important as provider code
 // under test may be using that package or another logging library outside of
 // terraform-plugin-log.
-func InitTestContext(ctx context.Context, t testing.T) context.Context {
+func InitTestContext(ctx context.Context, t testingiface.T) context.Context {
 	helperlogging.SetOutput(t)
 
 	ctx = tfsdklog.RegisterTestSink(ctx, t)

--- a/internal/plugintest/util.go
+++ b/internal/plugintest/util.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"testing"
 )
 
 func symlinkFile(src string, dest string) error {
@@ -144,43 +143,4 @@ func CopyDir(src, dest, baseDirName string) error {
 	}
 
 	return nil
-}
-
-// TestExpectTFatal provides a wrapper for logic which should call
-// (*testing.T).Fatal() or (*testing.T).Fatalf().
-//
-// Since we do not want the wrapping test to fail when an expected test error
-// occurs, it is required that the testLogic passed in uses
-// github.com/mitchellh/go-testing-interface.RuntimeT instead of the real
-// *testing.T.
-//
-// If Fatal() or Fatalf() is not called in the logic, the real (*testing.T).Fatal() will
-// be called to fail the test.
-func TestExpectTFatal(t *testing.T, testLogic func()) {
-	t.Helper()
-
-	var recoverIface interface{}
-
-	func() {
-		defer func() {
-			recoverIface = recover()
-		}()
-
-		testLogic()
-	}()
-
-	if recoverIface == nil {
-		t.Fatalf("expected t.Fatal(), got none")
-	}
-
-	recoverStr, ok := recoverIface.(string)
-
-	if !ok {
-		t.Fatalf("expected string from recover(), got: %v (%T)", recoverIface, recoverIface)
-	}
-
-	// this string is hardcoded in github.com/mitchellh/go-testing-interface
-	if !strings.HasPrefix(recoverStr, "testing.T failed, see logs for output") {
-		t.Fatalf("expected t.Fatal(), got: %s", recoverStr)
-	}
 }

--- a/internal/testingiface/doc.go
+++ b/internal/testingiface/doc.go
@@ -1,0 +1,25 @@
+// Package testingiface provides wrapper types compatible with the Go standard
+// library [testing] package. These wrappers are necessary for implementing
+// [testing] package helpers, since the Go standard library implementation is
+// not extensible and the existing code in this Go module is built on directly
+// interacting with [testing] functionality, such as calling [testing.T.Fatal].
+//
+// The [T] interface has all methods of the [testing.T] type and the [MockT]
+// type is a lightweight mock implementation of the [T] interface. There are a
+// collection of assertion helper functions such as:
+//   - [ExpectFail]: That the test logic called the equivalent of
+//     [testing.T.Error] or [testing.T.Fatal].
+//   - [ExpectParallel]: That the test logic called the equivalent of
+//     [testing.T.Parallel] and passed.
+//   - [ExpectPass]: That the test logic did not call the equivalent of
+//     [testing.T.Skip], since [testing] marks these tests as passing.
+//   - [ExpectSkip]: That the test logic called the equivalent of
+//     [testing.T.Skip].
+//
+// This code in this package is intentionally internal and should not be exposed
+// in the Go module API. It is compatible with the Go 1.17 [testing] package.
+// It replaces the archived github.com/mitchellh/go-testing-interface Go module,
+// but is implemented with different approaches that enable calls to behave
+// more closely to the Go standard library, such as calling [runtime.Goexit]
+// when skipping, and preserving any error/skip messaging.
+package testingiface

--- a/internal/testingiface/doc.go
+++ b/internal/testingiface/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 // Package testingiface provides wrapper types compatible with the Go standard
 // library [testing] package. These wrappers are necessary for implementing
 // [testing] package helpers, since the Go standard library implementation is

--- a/internal/testingiface/expect.go
+++ b/internal/testingiface/expect.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package testingiface
 
 import (

--- a/internal/testingiface/expect.go
+++ b/internal/testingiface/expect.go
@@ -1,0 +1,140 @@
+package testingiface
+
+import (
+	"sync"
+)
+
+// ExpectFailed provides a wrapper for test logic which should call any of the
+// following:
+//   - [testing.T.Error]
+//   - [testing.T.Errorf]
+//   - [testing.T.Fatal]
+//   - [testing.T.Fatalf]
+//
+// If none of those were called, the real [testing.T.Fatal] is called to fail
+// the test.
+func ExpectFail(t T, logic func(*MockT)) {
+	t.Helper()
+
+	mockT := &MockT{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		logic(mockT)
+	}()
+
+	wg.Wait()
+
+	if mockT.Failed() {
+		return
+	}
+
+	t.Fatal("expected test failure")
+}
+
+// ExpectParallel provides a wrapper for test logic which should call the
+// [testing.T.Parallel] method. If it doesn't, the real [testing.T.Fatal] is
+// called.
+func ExpectParallel(t T, logic func(*MockT)) {
+	t.Helper()
+
+	mockT := &MockT{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		logic(mockT)
+	}()
+
+	wg.Wait()
+
+	if mockT.Failed() {
+		t.Fatalf("unexpected test failure: %s", mockT.LastError())
+	}
+
+	if mockT.Skipped() {
+		t.Fatalf("unexpected test skip: %s", mockT.LastSkipped())
+	}
+
+	if mockT.IsParallel() {
+		return
+	}
+
+	t.Fatal("expected test parallel")
+}
+
+// ExpectPass provides a wrapper for test logic which should not call any of the
+// following, which would mark the real test as passing:
+//   - [testing.T.Skip]
+//   - [testing.T.Skipf]
+//
+// If one of those were called, the real [testing.T.Fatal] is called to fail
+// the test. This is only necessary to check for false positives with skipped
+// tests.
+func ExpectPass(t T, logic func(*MockT)) {
+	t.Helper()
+
+	mockT := &MockT{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		logic(mockT)
+	}()
+
+	wg.Wait()
+
+	if mockT.Failed() {
+		t.Fatalf("unexpected test failure: %s", mockT.LastError())
+	}
+
+	if mockT.Skipped() {
+		t.Fatalf("unexpected test skip: %s", mockT.LastSkipped())
+	}
+
+	// test passed as expected
+}
+
+// ExpectSkip provides a wrapper for test logic which should call any of the
+// following:
+//   - [testing.T.Skip]
+//   - [testing.T.Skipf]
+//
+// If none of those were called, the real [testing.T.Fatal] is called to fail
+// the test.
+func ExpectSkip(t T, logic func(*MockT)) {
+	t.Helper()
+
+	mockT := &MockT{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		logic(mockT)
+	}()
+
+	wg.Wait()
+
+	if mockT.Failed() {
+		t.Fatalf("unexpected test failure: %s", mockT.LastError())
+	}
+
+	if mockT.Skipped() {
+		return
+	}
+
+	t.Fatal("test passed, expected test skip")
+}

--- a/internal/testingiface/expect_test.go
+++ b/internal/testingiface/expect_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package testingiface_test
 
 import (

--- a/internal/testingiface/expect_test.go
+++ b/internal/testingiface/expect_test.go
@@ -1,0 +1,99 @@
+package testingiface_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
+)
+
+func TestExpectFail(t *testing.T) {
+	t.Parallel()
+
+	testingiface.ExpectPass(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectFail(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Fatal("test fatal")
+		})
+	})
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectFail(mockT1, func(_ *testingiface.MockT) {
+			// intentionally no test error or test skip
+		})
+	})
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectFail(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Skip("test skip")
+		})
+	})
+}
+
+func TestExpectParallel(t *testing.T) {
+	t.Parallel()
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectParallel(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Fatal("test fatal")
+		})
+	})
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectParallel(mockT1, func(_ *testingiface.MockT) {
+			// intentionally no test error or test skip
+		})
+	})
+
+	testingiface.ExpectPass(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectParallel(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Parallel()
+		})
+	})
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectParallel(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Skip("test skip")
+		})
+	})
+}
+
+func TestExpectPass(t *testing.T) {
+	t.Parallel()
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectPass(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Fatal("test fatal")
+		})
+	})
+
+	testingiface.ExpectPass(t, func(_ *testingiface.MockT) {
+		// intentionally no test error or test skip
+	})
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectPass(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Skip("test skip")
+		})
+	})
+}
+
+func TestExpectSkip(t *testing.T) {
+	t.Parallel()
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectSkip(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Fatal("test fatal")
+		})
+	})
+
+	testingiface.ExpectFail(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectSkip(mockT1, func(_ *testingiface.MockT) {
+			// intentionally no test error or test skip
+		})
+	})
+
+	testingiface.ExpectPass(t, func(mockT1 *testingiface.MockT) {
+		testingiface.ExpectSkip(mockT1, func(mockT2 *testingiface.MockT) {
+			mockT2.Skip("test skip")
+		})
+	})
+}

--- a/internal/testingiface/mockt.go
+++ b/internal/testingiface/mockt.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package testingiface
 
 import (

--- a/internal/testingiface/mockt.go
+++ b/internal/testingiface/mockt.go
@@ -1,0 +1,153 @@
+package testingiface
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+var _ T = (*MockT)(nil)
+
+// MockT is a lightweight, mock implementation of the non-extensible Go
+// standard library [*testing.T] implementation. This type should only be used
+// in the unit testing of functionality within this Go module and never exposed
+// in the Go module API.
+//
+// This type intentionally is not feature-complete and only includes the methods
+// necessary for the existing code in this Go module.
+type MockT struct {
+	// TestName can be set to the name of the test, such as calling the real
+	// [testing.T.Name]. This is returned in the [Name] method.
+	TestName string
+
+	isHelper    bool
+	isFailed    bool
+	isSkipped   bool
+	isParallel  bool
+	lastError   string
+	lastSkipped string
+}
+
+// T interface implementations
+
+func (t *MockT) Cleanup(func()) {
+	panic("not implemented")
+}
+
+func (t *MockT) Deadline() (deadline time.Time, ok bool) {
+	panic("not implemented")
+}
+
+func (t *MockT) Error(args ...any) {
+	t.lastError = fmt.Sprintln(args...)
+	t.Log(args...)
+	t.Fail()
+}
+
+func (t *MockT) Errorf(format string, args ...any) {
+	t.lastError = fmt.Sprintf(format, args...)
+	t.Logf(format, args...)
+	t.Fail()
+}
+
+func (t *MockT) Fail() {
+	t.isFailed = true
+}
+
+func (t *MockT) Failed() bool {
+	return t.isFailed
+}
+
+func (t *MockT) FailNow() {
+	t.Fail()
+	runtime.Goexit()
+}
+
+func (t *MockT) Fatal(args ...any) {
+	t.lastError = fmt.Sprintln(args...)
+	t.Log(args...)
+	t.FailNow()
+}
+
+func (t *MockT) Fatalf(format string, args ...any) {
+	t.lastError = fmt.Sprintf(format, args...)
+	t.Log(args...)
+	t.FailNow()
+}
+
+func (t *MockT) Helper() {
+	t.isHelper = true
+}
+
+func (t *MockT) Log(args ...any) {
+	if args == nil {
+		return
+	}
+
+	fmt.Fprintln(os.Stdout, args...)
+}
+
+func (t *MockT) Logf(format string, args ...any) {
+	if format == "" {
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, format, args...)
+}
+
+func (t *MockT) Name() string {
+	return t.TestName
+}
+
+func (t *MockT) Parallel() {
+	t.isParallel = true
+}
+
+func (t *MockT) Run(name string, f func(t *testing.T)) bool {
+	panic("not implemented")
+}
+
+func (t *MockT) Setenv(key string, value string) {
+	panic("not implemented")
+}
+
+func (t *MockT) Skip(args ...any) {
+	t.lastSkipped = fmt.Sprintln(args...)
+	t.Log(args...)
+	t.SkipNow()
+}
+
+func (t *MockT) Skipf(format string, args ...any) {
+	t.lastSkipped = fmt.Sprintf(format, args...)
+	t.Logf(format, args...)
+	t.SkipNow()
+}
+
+func (t *MockT) SkipNow() {
+	t.isSkipped = true
+	runtime.Goexit()
+}
+
+func (t *MockT) Skipped() bool {
+	return t.isSkipped
+}
+
+func (t *MockT) TempDir() string {
+	panic("not implemented")
+}
+
+// Custom methods
+
+func (t *MockT) IsParallel() bool {
+	return t.isParallel
+}
+
+func (t *MockT) LastError() string {
+	return t.lastError
+}
+
+func (t *MockT) LastSkipped() string {
+	return t.lastSkipped
+}

--- a/internal/testingiface/t.go
+++ b/internal/testingiface/t.go
@@ -1,0 +1,44 @@
+package testingiface
+
+// T is the interface that contains all the methods of the Go standard library
+// [*testing.T] type as of Go 1.17.
+//
+// For complete backwards compatibility, it explicitly does not include the
+// Deadline and Run methods to match the prior
+// github.com/mitchellh/go-testing-interface.T interface. If either of those
+// methods are needed, it should be relatively safe to add to this interface
+// under the guise that this internal interface should match the [*testing.T]
+// implementation.
+type T interface {
+	Cleanup(func())
+
+	// Excluded to match the prior github.com/mitchellh/go-testing-interface.T
+	// interface for complete backwards compatibility. It is relatively safe to
+	// introduce if necessary in the future though.
+	// Deadline() (deadline time.Time, ok bool)
+
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	Failed() bool
+	FailNow()
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Parallel()
+
+	// Excluded to match the prior github.com/mitchellh/go-testing-interface.T
+	// interface for complete backwards compatibility. It is relatively safe to
+	// introduce if necessary in the future though.
+	// Run(name string, f func(*testing.T)) bool
+
+	Setenv(key string, value string)
+	Skip(args ...any)
+	Skipf(format string, args ...any)
+	SkipNow()
+	Skipped() bool
+	TempDir() string
+}

--- a/internal/testingiface/t.go
+++ b/internal/testingiface/t.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package testingiface
 
 // T is the interface that contains all the methods of the Go standard library

--- a/tfversion/all_test.go
+++ b/tfversion/all_test.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	testinginterface "github.com/mitchellh/go-testing-interface"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -21,27 +20,29 @@ func Test_All_RunTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": providerserver.NewProviderServer(testprovider.Provider{}),
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.Any(
-				tfversion.All(
-					tfversion.RequireNot(version.Must(version.NewVersion("0.15.0"))),  //returns nil
-					tfversion.SkipIf(version.Must(version.NewVersion("1.2.0"))),       //returns nil
-					tfversion.RequireBelow(version.Must(version.NewVersion("1.2.0"))), //returns nil
-				),
-			),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `variable "a" {
-  					nullable = true
-					default  = "hello"
-				}`,
+	testingiface.ExpectPass(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.Any(
+					tfversion.All(
+						tfversion.RequireNot(version.Must(version.NewVersion("0.15.0"))),  //returns nil
+						tfversion.SkipIf(version.Must(version.NewVersion("1.2.0"))),       //returns nil
+						tfversion.RequireBelow(version.Must(version.NewVersion("1.2.0"))), //returns nil
+					),
+				),
+			},
+			Steps: []r.TestStep{
+				{
+					Config: `variable "a" {
+						nullable = true
+						default  = "hello"
+					}`,
+				},
+			},
+		})
 	})
 }
 
@@ -49,30 +50,30 @@ func Test_All_SkipTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.0.7")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.Any(
-				tfversion.All(
-					tfversion.RequireNot(version.Must(version.NewVersion("0.15.0"))),  //returns nil
-					tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))),    //returns skip
-					tfversion.SkipIf(version.Must(version.NewVersion("1.0.7"))),       //returns skip
-					tfversion.RequireBelow(version.Must(version.NewVersion("1.2.0"))), //returns nil
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.Any(
+					tfversion.All(
+						tfversion.RequireNot(version.Must(version.NewVersion("0.15.0"))),  //returns nil
+						tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))),    //returns skip
+						tfversion.SkipIf(version.Must(version.NewVersion("1.0.7"))),       //returns skip
+						tfversion.RequireBelow(version.Must(version.NewVersion("1.2.0"))), //returns nil
+					),
 				),
-			),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `variable "a" {
-  					nullable = true
-					default  = "hello"
-				}`,
 			},
-		},
+			Steps: []r.TestStep{
+				{
+					Config: `variable "a" {
+						nullable = true
+						default  = "hello"
+					}`,
+				},
+			},
+		})
 	})
 }
 
@@ -80,12 +81,10 @@ func Test_All_Error(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.Any(

--- a/tfversion/any_test.go
+++ b/tfversion/any_test.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	testinginterface "github.com/mitchellh/go-testing-interface"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -21,24 +20,26 @@ func Test_Any_RunTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": providerserver.NewProviderServer(testprovider.Provider{}),
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.Any(
-				tfversion.RequireNot(version.Must(version.NewVersion("1.1.0"))),   //returns error
-				tfversion.RequireBelow(version.Must(version.NewVersion("1.2.0"))), //returns nil
-			),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `variable "a" {
-  					nullable = true
-					default  = "hello"
-				}`,
+	testingiface.ExpectPass(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.Any(
+					tfversion.RequireNot(version.Must(version.NewVersion("1.1.0"))),   //returns error
+					tfversion.RequireBelow(version.Must(version.NewVersion("1.2.0"))), //returns nil
+				),
+			},
+			Steps: []r.TestStep{
+				{
+					Config: `variable "a" {
+						nullable = true
+						default  = "hello"
+					}`,
+				},
+			},
+		})
 	})
 }
 
@@ -46,26 +47,26 @@ func Test_Any_SkipTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.Any(
-				tfversion.SkipIf(version.Must(version.NewVersion("1.1.0"))),    //returns skip
-				tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))), //returns skip
-			),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `variable "a" {
-  					nullable = true
-					default  = "hello"
-				}`,
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.Any(
+					tfversion.SkipIf(version.Must(version.NewVersion("1.1.0"))),    //returns skip
+					tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))), //returns skip
+				),
 			},
-		},
+			Steps: []r.TestStep{
+				{
+					Config: `variable "a" {
+						nullable = true
+						default  = "hello"
+					}`,
+				},
+			},
+		})
 	})
 }
 
@@ -73,12 +74,10 @@ func Test_Any_Error(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.Any(

--- a/tfversion/require_above_test.go
+++ b/tfversion/require_above_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func Test_RequireAbove(t *testing.T) { //nolint:paralleltest
@@ -45,12 +43,10 @@ func Test_RequireAbove_Error(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.0.7")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.RequireAbove(version.Must(version.NewVersion("1.1.0"))),

--- a/tfversion/require_below_test.go
+++ b/tfversion/require_below_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func Test_RequireBelow(t *testing.T) { //nolint:paralleltest
@@ -22,9 +22,7 @@ func Test_RequireBelow(t *testing.T) { //nolint:paralleltest
 
 	r.UnitTest(t, r.TestCase{
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
-			},
+			"test": providerserver.NewProviderServer(testprovider.Provider{}),
 		},
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireBelow(version.Must(version.NewVersion("1.3.0"))),
@@ -46,12 +44,10 @@ func Test_RequireBelow_Error(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.4.0")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.RequireBelow(version.Must(version.NewVersion("1.3.0"))),

--- a/tfversion/require_between_test.go
+++ b/tfversion/require_between_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func Test_RequireBetween(t *testing.T) { //nolint:paralleltest
@@ -58,12 +58,10 @@ func Test_RequireBetween_Error_BelowMin(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.RequireBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
@@ -80,12 +78,10 @@ func Test_RequireBetween_Error_BelowMin(t *testing.T) { //nolint:paralleltest
 func Test_RequireBetween_Error_EqToMax(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.3.0")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.RequireBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),

--- a/tfversion/require_not_test.go
+++ b/tfversion/require_not_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func Test_RequireNot(t *testing.T) { //nolint:paralleltest
@@ -41,12 +39,10 @@ func Test_RequireNot_Error(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	plugintest.TestExpectTFatal(t, func() {
-		r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+	testingiface.ExpectFail(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
 			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-				"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-					return nil, nil
-				},
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 				tfversion.RequireNot(version.Must(version.NewVersion("1.1.0"))),

--- a/tfversion/skip_above_test.go
+++ b/tfversion/skip_above_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -17,25 +20,25 @@ func Test_SkipAbove_SkipTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.3.0")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipAbove(version.Must(version.NewVersion("1.2.9"))),
-		},
-		Steps: []r.TestStep{
-			{
-				//module_variable_optional_attrs experiment is deprecated in TF v1.3.0
-				Config: `
-					terraform {
-  						experiments = [module_variable_optional_attrs]
-					}
-				`,
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipAbove(version.Must(version.NewVersion("1.2.9"))),
 			},
-		},
+			Steps: []r.TestStep{
+				{
+					//module_variable_optional_attrs experiment is deprecated in TF v1.3.0
+					Config: `
+						terraform {
+							experiments = [module_variable_optional_attrs]
+						}
+					`,
+				},
+			},
+		})
 	})
 }
 
@@ -43,24 +46,24 @@ func Test_SkipAbove_RunTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.9")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectPass(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipAbove(version.Must(version.NewVersion("1.2.9"))),
-		},
-		Steps: []r.TestStep{
-			{
-				//module_variable_optional_attrs experiment is deprecated in TF v1.3.0
-				Config: `
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipAbove(version.Must(version.NewVersion("1.2.9"))),
+			},
+			Steps: []r.TestStep{
+				{
+					//module_variable_optional_attrs experiment is deprecated in TF v1.3.0
+					Config: `
 					terraform {
   						experiments = [module_variable_optional_attrs]
 					}
 				`,
+				},
 			},
-		},
+		})
 	})
 }

--- a/tfversion/skip_below_test.go
+++ b/tfversion/skip_below_test.go
@@ -12,6 +12,7 @@ import (
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -19,24 +20,24 @@ func Test_SkipBelow_SkipTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.0.7")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.1.0"))),
-		},
-		Steps: []r.TestStep{
-			{
-				//nullable argument only available in TF v1.1.0+
-				Config: `variable "a" {
-  					nullable = true
-					default  = "hello"
-				}`,
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBelow(version.Must(version.NewVersion("1.1.0"))),
 			},
-		},
+			Steps: []r.TestStep{
+				{
+					//nullable argument only available in TF v1.1.0+
+					Config: `variable "a" {
+						nullable = true
+						default  = "hello"
+					}`,
+				},
+			},
+		})
 	})
 }
 
@@ -44,21 +45,23 @@ func Test_SkipBelow_RunTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": providerserver.NewProviderServer(testprovider.Provider{}),
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.1.0"))),
-		},
-		Steps: []r.TestStep{
-			{
-				//nullable argument only available in TF v1.1.0+
-				Config: `variable "a" {
-  					nullable = true
-					default  = "hello"
-				}`,
+	testingiface.ExpectPass(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBelow(version.Must(version.NewVersion("1.1.0"))),
+			},
+			Steps: []r.TestStep{
+				{
+					//nullable argument only available in TF v1.1.0+
+					Config: `variable "a" {
+						nullable = true
+						default  = "hello"
+					}`,
+				},
+			},
+		})
 	})
 }

--- a/tfversion/skip_between_test.go
+++ b/tfversion/skip_between_test.go
@@ -12,46 +12,45 @@ import (
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func Test_SkipBetween_SkipTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.0")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
-		},
-		Steps: []r.TestStep{
-			{
-				//module_variable_optional_attrs experiment is deprecated in TF v1.3.0
-				//precondition block is only available in TF v1.2.0+
-				Config: `
-					terraform {
-  						experiments = [module_variable_optional_attrs]
-					}
-
-					locals {
-						ex_var = "hello"
-					}
-
-					output "example" {
-						value = "output"
-						precondition {
-							condition = local.ex_var != "hi"
-							error_message = "precondition_error"
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
+			},
+			Steps: []r.TestStep{
+				{
+					//module_variable_optional_attrs experiment is deprecated in TF v1.3.0
+					//precondition block is only available in TF v1.2.0+
+					Config: `
+						terraform {
+							experiments = [module_variable_optional_attrs]
 						}
-					}`,
+
+						locals {
+							ex_var = "hello"
+						}
+
+						output "example" {
+							value = "output"
+							precondition {
+								condition = local.ex_var != "hi"
+								error_message = "precondition_error"
+							}
+						}`,
+				},
 			},
-		},
+		})
 	})
 }
 
@@ -59,18 +58,20 @@ func Test_SkipBetween_RunTest_AboveMax(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.3.0")
 
-	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": providerserver.NewProviderServer(testprovider.Provider{}),
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `//non-empty config`,
+	testingiface.ExpectPass(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
+			},
+			Steps: []r.TestStep{
+				{
+					Config: `//non-empty config`,
+				},
+			},
+		})
 	})
 }
 
@@ -78,17 +79,19 @@ func Test_SkipBetween_RunTest_EqToMin(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.2.0")
 
-	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": providerserver.NewProviderServer(testprovider.Provider{}),
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `//non-empty config`,
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBetween(version.Must(version.NewVersion("1.2.0")), version.Must(version.NewVersion("1.3.0"))),
+			},
+			Steps: []r.TestStep{
+				{
+					Config: `//non-empty config`,
+				},
+			},
+		})
 	})
 }

--- a/tfversion/skip_if_test.go
+++ b/tfversion/skip_if_test.go
@@ -12,29 +12,28 @@ import (
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testingiface"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-
-	testinginterface "github.com/mitchellh/go-testing-interface"
 )
 
 func Test_SkipIf_SkipTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.4.3")
 
-	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
-				return nil, nil
+	testingiface.ExpectSkip(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipIf(version.Must(version.NewVersion("1.4.3"))),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `//non-empty config`,
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipIf(version.Must(version.NewVersion("1.4.3"))),
 			},
-		},
+			Steps: []r.TestStep{
+				{
+					Config: `//non-empty config`,
+				},
+			},
+		})
 	})
 }
 
@@ -42,17 +41,19 @@ func Test_SkipIf_RunTest(t *testing.T) { //nolint:paralleltest
 	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
 	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.1.0")
 
-	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
-		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
-			"test": providerserver.NewProviderServer(testprovider.Provider{}),
-		},
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipIf(version.Must(version.NewVersion("1.2.0"))),
-		},
-		Steps: []r.TestStep{
-			{
-				Config: `//non-empty config`,
+	testingiface.ExpectPass(t, func(mockT *testingiface.MockT) {
+		r.UnitTest(mockT, r.TestCase{
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"test": providerserver.NewProviderServer(testprovider.Provider{}),
 			},
-		},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipIf(version.Must(version.NewVersion("1.2.0"))),
+			},
+			Steps: []r.TestStep{
+				{
+					Config: `//non-empty config`,
+				},
+			},
+		})
 	})
 }


### PR DESCRIPTION
Closes #254
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/303

_Note: This change is easiest to view with whitespace changes ignored._

As part of upcoming efforts to consider prerelease versioning more pragmatically in the `tfversion` package checks, the need to properly unit test `(*testing.T).Skip()` and friends behaviors is more apparent. Similar to issues with testing `(*testing.T).Fatal()` behaviors, the Go standard library in general is not the most friendly to capture test helper behaviors since the `testing.T` implementation is not intended to be extensible. This change was initially intended to extend our current usage of `github.com/mitchellh/go-testing-interface` as a stopgap, however while attempting to implement skip assertion testing, the `RuntimeT` implementation did not call `runtime.Goexit()` and would cause tests to continue to execute test logic after skipping even though in reality they would not. While the tests could be fixed to ensure they still passed due to that behavior change, it felt like a good time as any to replace the now-unsuitable and archived `github.com/mitchellh/go-testing-interface` with our own internal implementation.

The new `internal/testingiface.T` interface is a wholesale duplicate interface to the prior `github.com/mitchellh/go-testing-interface.T` interface. Swapping this interface in exported functions, such as `helper/resource.Test()` is only a compatibility issue for consumers if by chance they were implementing a wrapping function that also depended on `github.com/mitchellh/go-testing-interface.T` and passed that implementation detail directly to function calls of this Go module. This is a gray compatibility area as the intention of using `github.com/mitchellh/go-testing-interface.T` was for consumers to use real `*testing.T` implementations, which will work the same after this change, but it was not appropriately documented that extensions of exported functionality using `github.com/mitchellh/go-testing-interface.T` should not rely on that explicitly. Changing this detail is therefore a pragmatic compromise that it is more important to prioritize and document the intended usage while removing the archived dependency, which is almost exclusively how the ecosystem interacts with the functionality, over the potential of compatibility issues in a very small subset of the ecosystem.

Since `(*testing.T).Skip()` is considered a passing test, there are now assertions whether skipping was called or not, as expected, in the existing `tfversion` package tests. The new `internal/testingiface` package also includes similar assertion helpers for `(*testing.T).Fatal()` and `(*testing.T).Parallel()` for consistency and cleans up some existing logic.