### PR TITLE
tfversion: Add `SkipIfNotAlpha` version check

### DIFF
--- a/.changes/unreleased/FEATURES-20241108-160634.yaml
+++ b/.changes/unreleased/FEATURES-20241108-160634.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: 'tfversion: Added `SkipIfNotAlpha` version check for testing experimental features
+  of alpha Terraform builds.'
+time: 2024-11-08T16:06:34.662822-05:00
+custom:
+  Issue: "388"

--- a/helper/resource/testdata/TestTest_ConfigDirectory_TestNameDirectory_MultipleFiles_Vars/vars.tf
+++ b/helper/resource/testdata/TestTest_ConfigDirectory_TestNameDirectory_MultipleFiles_Vars/vars.tf
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "length" {
+  type = number
+}
+
+variable "numeric" {
+  type = bool
+}

--- a/plancheck/expect_deferred_change_test.go
+++ b/plancheck/expect_deferred_change_test.go
@@ -24,7 +24,7 @@ func Test_ExpectDeferredChange_Reason_Match(t *testing.T) {
 	r.Test(t, r.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_9_0),
-			tfversion.SkipIfNotPrerelease(),
+			tfversion.SkipIfNotAlpha(),
 		},
 		AdditionalCLIOptions: &r.AdditionalCLIOptions{
 			Plan:  r.PlanOptions{AllowDeferral: true},
@@ -75,7 +75,7 @@ func Test_ExpectDeferredChange_Reason_NoMatch(t *testing.T) {
 	r.Test(t, r.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_9_0),
-			tfversion.SkipIfNotPrerelease(),
+			tfversion.SkipIfNotAlpha(),
 		},
 		AdditionalCLIOptions: &r.AdditionalCLIOptions{
 			Plan:  r.PlanOptions{AllowDeferral: true},
@@ -127,7 +127,7 @@ func Test_ExpectDeferredChange_NoDeferredChanges(t *testing.T) {
 	r.Test(t, r.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_9_0),
-			tfversion.SkipIfNotPrerelease(),
+			tfversion.SkipIfNotAlpha(),
 		},
 		AdditionalCLIOptions: &r.AdditionalCLIOptions{
 			Plan:  r.PlanOptions{AllowDeferral: true},

--- a/plancheck/expect_no_deferred_changes_test.go
+++ b/plancheck/expect_no_deferred_changes_test.go
@@ -24,7 +24,7 @@ func Test_ExpectNoDeferredChange(t *testing.T) {
 	r.Test(t, r.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_9_0),
-			tfversion.SkipIfNotPrerelease(),
+			tfversion.SkipIfNotAlpha(),
 		},
 		AdditionalCLIOptions: &r.AdditionalCLIOptions{
 			Plan:  r.PlanOptions{AllowDeferral: true},
@@ -72,7 +72,7 @@ func Test_ExpectNoDeferredChange_OneDeferral(t *testing.T) {
 	r.Test(t, r.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_9_0),
-			tfversion.SkipIfNotPrerelease(),
+			tfversion.SkipIfNotAlpha(),
 		},
 		AdditionalCLIOptions: &r.AdditionalCLIOptions{
 			Plan:  r.PlanOptions{AllowDeferral: true},
@@ -124,7 +124,7 @@ func Test_ExpectNoDeferredChange_MultipleDeferrals(t *testing.T) {
 	r.Test(t, r.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_9_0),
-			tfversion.SkipIfNotPrerelease(),
+			tfversion.SkipIfNotAlpha(),
 		},
 		AdditionalCLIOptions: &r.AdditionalCLIOptions{
 			Plan:  r.PlanOptions{AllowDeferral: true},

--- a/tfversion/skip_if_not_alpha.go
+++ b/tfversion/skip_if_not_alpha.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfversion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// SkipIfNotAlpha will skip (pass) the test if the Terraform CLI
+// version is not an alpha prerelease (for example, 1.10.0-alpha20241023).
+//
+// Alpha builds of Terraform include experimental features, so this version check
+// can be used for acceptance testing of experimental features, such as deferred actions.
+func SkipIfNotAlpha() TerraformVersionCheck {
+	return skipIfNotAlphaCheck{}
+}
+
+// skipIfNotAlphaCheck implements the TerraformVersionCheck interface
+type skipIfNotAlphaCheck struct{}
+
+// CheckTerraformVersion satisfies the TerraformVersionCheck interface.
+func (s skipIfNotAlphaCheck) CheckTerraformVersion(ctx context.Context, req CheckTerraformVersionRequest, resp *CheckTerraformVersionResponse) {
+	if strings.Contains(req.TerraformVersion.Prerelease(), "alpha") {
+		return
+	}
+
+	resp.Skip = fmt.Sprintf("Terraform CLI version %s is not an alpha build: skipping test.", req.TerraformVersion)
+}

--- a/tfversion/skip_if_not_alpha_test.go
+++ b/tfversion/skip_if_not_alpha_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfversion_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	testinginterface "github.com/mitchellh/go-testing-interface"
+)
+
+func Test_SkipIfNotAlpha_SkipTest_Stable(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
+	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.8.0")
+
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"test": func() (tfprotov6.ProviderServer, error) { //nolint:unparam // required signature
+				return nil, nil
+			},
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipIfNotAlpha(),
+		},
+		Steps: []r.TestStep{
+			{
+				Config: `//non-empty config`,
+			},
+		},
+	})
+}
+
+func Test_SkipIfNotAlpha_SkipTest_Beta1(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
+	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.8.0-beta1")
+
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"test": providerserver.NewProviderServer(testprovider.Provider{}),
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipIfNotAlpha(),
+		},
+		Steps: []r.TestStep{
+			{
+				Config: `//non-empty config`,
+			},
+		},
+	})
+}
+func Test_SkipIfNotAlpha_SkipTest_RC(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
+	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.8.0-rc2")
+
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"test": providerserver.NewProviderServer(testprovider.Provider{}),
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipIfNotAlpha(),
+		},
+		Steps: []r.TestStep{
+			{
+				Config: `//non-empty config`,
+			},
+		},
+	})
+}
+
+func Test_SkipIfNotAlpha_RunTest_Alpha(t *testing.T) { //nolint:paralleltest
+	t.Setenv("TF_ACC_TERRAFORM_PATH", "")
+	t.Setenv("TF_ACC_TERRAFORM_VERSION", "1.9.0-alpha20240501")
+
+	r.UnitTest(&testinginterface.RuntimeT{}, r.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"test": providerserver.NewProviderServer(testprovider.Provider{}),
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipIfNotAlpha(),
+		},
+		Steps: []r.TestStep{
+			{
+				Config: `//non-empty config`,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Since we've recently added beta prereleases to our acceptance testing, we started getting test failures for experimental features like deferred actions that use the `SkipIfNotPrerelease` version check. That's because the only prerelease builds that get experimental features (like deferred actions) are `alpha` and source builds.

None of our CI uses source builds, so I just created a new `SkipIfNotAlpha` version check we can use for experimental features, while allowing `beta` builds to run in our CI successfully 👍🏻 