### PR TITLE
Allow filtering of sweepers using regular expressions

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -200,10 +200,15 @@ func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
 		return source
 	}
 
+	filterRegexes := make([]regexp.Regexp, len(filterSlice))
+	for i, filter := range filterSlice {
+		filterRegexes[i] = *regexp.MustCompile(filter)
+	}
+
 	sweepers := make(map[string]*Sweeper)
 	for name := range source {
-		for _, s := range filterSlice {
-			if strings.Contains(strings.ToLower(name), s) {
+		for _, r := range filterRegexes {
+			if r.MatchString(strings.ToLower(name)) {
 				for foundName, foundSweeper := range filterSweeperWithDependencies(name, source) {
 					sweepers[foundName] = foundSweeper
 				}

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -193,15 +193,17 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 // to be ran, and returns a filtered set from the list of all of sweepers to
 // run based on the names given.
 func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
-	filterSlice := strings.Split(strings.ToLower(f), ",")
+	filterSlice := strings.Split(f, ",")
 	if len(filterSlice) == 1 && filterSlice[0] == "" {
 		// if the filter slice is a single element of "" then no sweeper list was
 		// given, so just return the full list
 		return source
 	}
 
+	// Downcase filter elements and create regular expressions
 	filterRegexes := make([]regexp.Regexp, len(filterSlice))
 	for i, filter := range filterSlice {
+		filter = strings.ToLower(filter)
 		filterRegexes[i] = *regexp.MustCompile(filter)
 	}
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -212,7 +212,7 @@ func TestFilterSweepers(t *testing.T) {
 			ExpectedSweepers: []string{"aws_dummy"},
 		},
 		{
-			Name: "with dep",
+			Name: "with dependencies",
 			Sweepers: map[string]*Sweeper{
 				"aws_dummy": {
 					Name: "aws_dummy",
@@ -290,7 +290,7 @@ func TestFilterSweepers(t *testing.T) {
 			Filter:           "aws_dummy,aws_sub",
 		},
 		{
-			Name: "with dep and filter",
+			Name: "with dependency and filter",
 			Sweepers: map[string]*Sweeper{
 				"aws_dummy": {
 					Name: "aws_dummy",
@@ -393,7 +393,7 @@ func TestFilterSweepers(t *testing.T) {
 			Filter:           "matching_level1",
 		},
 		{
-			Name: "with nested depenencies and middle level filter",
+			Name: "with nested dependencies and middle level filter",
 			Sweepers: map[string]*Sweeper{
 				"not_matching": {
 					Name: "not_matching",
@@ -418,7 +418,7 @@ func TestFilterSweepers(t *testing.T) {
 			Filter:           "matching_level2",
 		},
 		{
-			Name: "with nested depenencies and bottom level filter",
+			Name: "with nested dependencies and bottom level filter",
 			Sweepers: map[string]*Sweeper{
 				"not_matching": {
 					Name: "not_matching",

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -251,6 +251,25 @@ func TestFilterSweepers(t *testing.T) {
 			Filter:           "aws_dummy",
 		},
 		{
+			Name: "with regex filter",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": {
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": {
+					Name: "aws_top",
+					F:    mockSweeperFunc,
+				},
+				"aws_sub": {
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedSweepers: []string{"aws_dummy", "aws_sub", "aws_top"},
+			Filter:           "^aws_",
+		},
+		{
 			Name: "with two filters",
 			Sweepers: map[string]*Sweeper{
 				"aws_dummy": {
@@ -310,7 +329,46 @@ func TestFilterSweepers(t *testing.T) {
 			Filter: "none",
 		},
 		{
-			Name: "with nested depenencies and top level filter",
+			Name: "with non-matching regex filter",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": {
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": {
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": {
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			Filter: "^aws_$",
+		},
+		{
+			Name: "with redundant filter",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": {
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": {
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": {
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedSweepers: []string{"aws_sub", "aws_top", "aws_dummy"},
+			Filter:           "aws_,aws_dummy",
+		},
+		{
+			Name: "with nested dependencies and top level filter",
 			Sweepers: map[string]*Sweeper{
 				"not_matching": {
 					Name: "not_matching",


### PR DESCRIPTION
This PR allows users to filter sweepers using regular expressions. Currently if a user uses `^aws_foo$` as a filter it will look for a sweeper whose name contains the string "^aws_foo$". Now the string will be interpreted as a regex.

This PR maintains the previous down-casing of filters to avoid breaking changes. 