### PR TITLE
tfversion: Add variable for version 1.11.0

### DIFF
--- a/tfversion/versions.go
+++ b/tfversion/versions.go
@@ -37,4 +37,5 @@ var (
 	Version1_8_0  *version.Version = version.Must(version.NewVersion("1.8.0"))
 	Version1_9_0  *version.Version = version.Must(version.NewVersion("1.9.0"))
 	Version1_10_0 *version.Version = version.Must(version.NewVersion("1.10.0"))
+	Version1_11_0 *version.Version = version.Must(version.NewVersion("1.11.0"))
 )


### PR DESCRIPTION
Terraform 1.11.0-beta1 will be releasing soon. We can come back and retroactively add a changelog if we don't have any `terraform-plugin-testing` releases upcoming (we don't typically add them for new version variables)