### PR TITLE
Add additional import test modes 

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -454,6 +454,14 @@ type ExternalProvider struct {
 	Source            string // the provider source
 }
 
+type ImportStateKind byte
+
+const (
+	ImportCommandWithId ImportStateKind = iota
+	ImportBlockWithId
+	ImportBlockWithResourceIdentity
+)
+
 // TestStep is a single apply sequence of a test, done within the
 // context of a state.
 //
@@ -632,6 +640,8 @@ type TestStep struct {
 	// by importing the resource with ResourceName (must be set) and the
 	// ID of that resource.
 	ImportState bool
+
+	ImportStateKind ImportStateKind
 
 	// ImportStateId is the ID to perform an ImportState operation with.
 	// This is optional. If it isn't set, then the resource ID is automatically

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -133,7 +133,7 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 
 	// use this to track last step successfully applied
 	// acts as default for import tests
-	var appliedCfg teststep.Config
+	var appliedCfg string
 	var stepNumber int
 
 	for stepIndex, step := range c.Steps {
@@ -426,7 +426,7 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 				}
 			}
 
-			mergedConfig, err := step.mergedConfig(ctx, c, hasTerraformBlock, hasProviderBlock, helper.TerraformVersion())
+			appliedCfg, err = step.mergedConfig(ctx, c, hasTerraformBlock, hasProviderBlock, helper.TerraformVersion())
 
 			if err != nil {
 				logging.HelperResourceError(ctx,
@@ -435,18 +435,6 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 				)
 				t.Fatalf("Error generating merged configuration: %s", err)
 			}
-
-			confRequest := teststep.PrepareConfigurationRequest{
-				Directory: step.ConfigDirectory,
-				File:      step.ConfigFile,
-				Raw:       mergedConfig,
-				TestStepConfigRequest: config.TestStepConfigRequest{
-					StepNumber: stepIndex + 1,
-					TestName:   t.Name(),
-				},
-			}.Exec()
-
-			appliedCfg = teststep.Configuration(confRequest)
 
 			logging.HelperResourceDebug(ctx, "Finished TestStep")
 

--- a/helper/resource/testing_new_import_block_id_test.go
+++ b/helper/resource/testing_new_import_block_id_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestTest_TestStep_ImportBlockId(t *testing.T) {
+	t.Parallel()
+
+	UnitTest(t, TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_5_0), // ProtoV6ProviderFactories
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_container": {
+						CreateResponse: &resource.CreateResponse{
+							NewState: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id":       tftypes.String,
+										"location": tftypes.String,
+										"name":     tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"id":       tftypes.NewValue(tftypes.String, "westeurope/somevalue"),
+									"location": tftypes.NewValue(tftypes.String, "westeurope"),
+									"name":     tftypes.NewValue(tftypes.String, "somevalue"),
+								},
+							),
+						},
+						ImportStateResponse: &resource.ImportStateResponse{
+							State: tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"id":       tftypes.String,
+										"location": tftypes.String,
+										"name":     tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"id":       tftypes.NewValue(tftypes.String, "westeurope/somevalue"),
+									"location": tftypes.NewValue(tftypes.String, "westeurope"),
+									"name":     tftypes.NewValue(tftypes.String, "somevalue"),
+								},
+							),
+						},
+						SchemaResponse: &resource.SchemaResponse{
+							Schema: &tfprotov6.Schema{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "id",
+											Type:     tftypes.String,
+											Computed: true,
+										},
+										{
+											Name:     "location",
+											Type:     tftypes.String,
+											Required: true,
+										},
+										{
+											Name:     "name",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		},
+		Steps: []TestStep{
+			{
+				Config: `
+				resource "examplecloud_container" "test" {
+					location = "westeurope"
+					name     = "somevalue"
+				}`,
+			},
+			{
+				ResourceName:      "examplecloud_container.test",
+				ImportState:       true,
+				ImportStateKind:   ImportBlockWithId,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -93,10 +93,6 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 
 	logging.HelperResourceTrace(ctx, fmt.Sprintf("Using import identifier: %s", importId))
 
-	if testStepConfig == nil {
-		logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")
-	}
-
 	// Create working directory for import tests
 	if testStepConfig == nil {
 		logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -6,19 +6,18 @@ package resource
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-exec/tfexec"
 	"reflect"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/go-testing-interface"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/hashicorp/terraform-plugin-testing/internal/logging"
 	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/teststep"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest.Helper, wd *plugintest.WorkingDir, step TestStep, cfgRaw string, providers *providerFactories, stepIndex int) error {

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -93,7 +93,7 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 
 	logging.HelperResourceTrace(ctx, fmt.Sprintf("Using import identifier: %s", importId))
 
-	// Create working directory for import tests
+	// Prepare the test config dependent on the kind of import test being performed
 	if testStepConfig == nil {
 		logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")
 
@@ -122,7 +122,6 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 		}.Exec()
 
 		testStepConfig = teststep.Configuration(confRequest)
-		//testStepConfig = cfg
 		if testStepConfig == nil {
 			t.Fatal("Cannot import state with no specified config")
 		}


### PR DESCRIPTION
Based off of https://github.com/hashicorp/terraform-plugin-testing/pull/431

TODOs:

- [ ] Add additional test cases e.g. for `ImportStateVerifyIgnore`, `SkipDataSource`, `ExpectError`?

