### PR TITLE
Add comments for UDR migration

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,5 +1,8 @@
 # Terraform Documentation
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 This directory contains the portions of [the Terraform website][terraform.io] that pertain to the Terraform Plugin Testing.
 
 The files in this directory are intended to be used in conjunction with

--- a/website/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -5,6 +5,9 @@ description: >-
   in conjunction with Terraform configuration.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Configuration
 
 The configuration used during the execution of an acceptance test can be specified at the [TestStep](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestStep) level by populating one of the following mutually exclusive fields:

--- a/website/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
@@ -4,6 +4,9 @@ description: >-
     Guidance on how to test ephemeral resources and data.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 <Highlight>
 
 Ephemeral resource support is in technical preview and offered without compatibility promises until Terraform 1.10 is generally available.

--- a/website/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/index.mdx
@@ -5,6 +5,9 @@ description: |-
   imitate applying one or more configuration files.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Acceptance Tests
 
 In order to deliver on our promise to be safe and predictable, we need to be

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -4,6 +4,9 @@ description: >-
     Bool Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Bool Known Value Checks
 
 The known value checks that are available for bool values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -4,6 +4,9 @@ description: >-
     Custom Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Custom Known Value Checks
 
 Custom known value checks can be created by implementing the [knownvalue.Check](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/knownvalue#Check) interface.

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -4,6 +4,9 @@ description: >-
     Float32 Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Float32 Known Value Checks
 
 The known value checks that are available for float32 values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -4,6 +4,9 @@ description: >-
     Float64 Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Float64 Known Value Checks
 
 The known value checks that are available for float64 values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -5,6 +5,9 @@ description: >-
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Known Value Checks
 
 Known Value Checks are for use in conjunction with [Plan Checks](/terraform/plugin/testing/acceptance-tests/plan-checks), and [State Checks](/terraform/plugin/testing/acceptance-tests/state-checks) which leverage the [terraform-json](https://pkg.go.dev/github.com/hashicorp/terraform-json) representation of a Terraform plan.

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -4,6 +4,9 @@ description: >-
     Int32 Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Int32 Known Value Checks
 
 The known value checks that are available for int32 values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -4,6 +4,9 @@ description: >-
     Int64 Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Int64 Known Value Checks
 
 The known value checks that are available for int64 values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -4,6 +4,9 @@ description: >-
     List Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # List Known Value Checks
 
 The known value checks that are available for list values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -4,6 +4,9 @@ description: >-
     Map Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Map Known Value Checks
 
 The known value checks that are available for map values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -4,6 +4,9 @@ description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # NotNull Known Value Checks
 
 The known value checks that are available for values that are not null are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -4,6 +4,9 @@ description: >-
     Null Value Checks for use with Plan Checks or State Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Null Known Value Checks
 
 The known value checks that are available for null values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -4,6 +4,9 @@ description: >-
     Number Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Number Known Value Checks
 
 The known value checks that are available for number values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -4,6 +4,9 @@ description: >-
     Object Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Object Known Value Checks
 
 The known value checks that are available for object values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -4,6 +4,9 @@ description: >-
     Set Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Set Known Value Checks
 
 The known value checks that are available for set values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -4,6 +4,9 @@ description: >-
     String Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # String Known Value Checks
 
 The known value checks that are available for string values are:

--- a/website/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -4,6 +4,9 @@ description: >-
     Tuple Value Checks for use with Plan Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Tuple Known Value Checks
 
 <Note>

--- a/website/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -4,6 +4,9 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Custom Plan Checks
 
 The package [`plancheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/plancheck) also provides the [`PlanCheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/plancheck#PlanCheck) interface, which can be implemented for a custom plan check.

--- a/website/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Plan Checks
 
 During the **Lifecycle (config)** and **Refresh** [modes](/terraform/plugin/testing/acceptance-tests/teststep#test-modes) of a `TestStep`, the testing framework will run `terraform plan` before and after certain operations. For example, the **Lifecycle (config)** mode will run a plan before the `terraform apply` phase, as well as a plan before and after the `terraform refresh` phase.

--- a/website/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in Output Value Plan Checks for common use-cases.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Output Plan Checks
 
 The `terraform-plugin-testing` module provides a package [`plancheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/plancheck) with built-in output value plan checks for common use-cases:

--- a/website/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resource Plan Checks
 
 The `terraform-plugin-testing` module provides a package [`plancheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/plancheck) with built-in managed resource, and data source plan checks for common use-cases:

--- a/website/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -4,6 +4,9 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Custom State Checks
 
 The package [`statecheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/statecheck) also provides the [`StateCheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/statecheck#StateCheck) interface, which can be implemented for a custom state check.

--- a/website/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # State Checks
 
 During the **Lifecycle (config)** [mode](/terraform/plugin/testing/acceptance-tests/teststep#test-modes) of a `TestStep`, the testing framework will run `terraform apply`.

--- a/website/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in Output Value State Checks for common use-cases.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Output State Checks
 
 The `terraform-plugin-testing` module provides a package [`statecheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/statecheck) with built-in output value state checks for common use-cases:

--- a/website/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resource State Checks
 
 The `terraform-plugin-testing` module provides a package [`statecheck`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/statecheck) with built-in managed resource, and data source state checks for common use-cases:

--- a/website/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -5,6 +5,9 @@ description: >-
   testing framework. Sweepers clean up leftover infrastructure.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Sweepers
 
 Acceptance tests in Terraform provision and verify real infrastructure using [Terraform's testing framework](/terraform/plugin/testing/acceptance-tests). Ideally all infrastructure created is then destroyed within the lifecycle of a test, however the reality is that there are several situations that can arise where resources created during a test are “leaked”. Leaked test resources are resources created by Terraform during a test, but Terraform either failed to destroy them as part of the test, or the test falsely reported all resources were destroyed after completing the test. Common causes are intermittent errors or failures in vendor APIs, or developer error in the resource code or test.

--- a/website/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -5,6 +5,9 @@ description: |-
   creates a set of resources then verifies the new infrastructure.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Acceptance Tests: TestCases
 
 Acceptance tests are expressed in terms of **Test Cases**, each using one or

--- a/website/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -5,6 +5,9 @@ description: |-
   file to a given state.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Acceptance Tests: TestSteps
 
 `TestStep`s represent the application of an actual Terraform configuration file

--- a/website/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -5,6 +5,9 @@ description: >-
     Attribute paths represent the location of an attribute within Terraform JSON data.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform JSON Paths
 
 An exact location within Terraform JSON data is referred to as a Terraform JSON or tfjson path.

--- a/website/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -5,6 +5,9 @@ description: >-
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Version Checks
 
 **Terraform Version Checks** are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The checks are executed at the beginning of the TestCase before any TestStep is executed.

--- a/website/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/website/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -5,6 +5,9 @@ description: >-
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Value Comparers
 
 <Note>

--- a/website/docs/plugin/testing/index.mdx
+++ b/website/docs/plugin/testing/index.mdx
@@ -5,6 +5,9 @@ description: |-
   plugins.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Testing Terraform Plugins
 
 Here we cover information needed to write successful tests for Terraform

--- a/website/docs/plugin/testing/migrating.mdx
+++ b/website/docs/plugin/testing/migrating.mdx
@@ -4,6 +4,9 @@ description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Overview
 
 This guide helps you migrate a Terraform provider's acceptance testing dependencies from SDKv2 to the plugin testing module. We recommend migrating to terraform-plugin-testing to take advantage of new features of the testing module and to avoid importing the SDKv2 for providers that are built on the plugin Framework.

--- a/website/docs/plugin/testing/testing-patterns.mdx
+++ b/website/docs/plugin/testing/testing-patterns.mdx
@@ -5,6 +5,9 @@ description: |-
   Terraform resources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Testing Patterns
 
 In [Testing Terraform Plugins][1] we introduce Terraform's Testing Framework,

--- a/website/docs/plugin/testing/unit-testing.mdx
+++ b/website/docs/plugin/testing/unit-testing.mdx
@@ -5,6 +5,9 @@ description: |-
   flatten API responses into data structures that Terraform stores as state.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Unit Testing
 
 Testing plugin code in small, isolated units is distinct from Acceptance Tests,


### PR DESCRIPTION
### Description

We are migrating the terraform-plugin-* documentation to a unified HashiCorp product documentation repository. As a result of this migration, the unified repo (web-unified-docs) will be the source of truth.

This PR adds a noticed to all existing MDX files in the original location so folks know where to contribute. We plan on deprecating and removing the files in /website.

This PR will be merged after docs have been migrated