### PR TITLE
chore: Add `prerelease: auto` for future pre-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,5 +5,6 @@ builds:
 milestones:
   - close: true
 release:
+  prerelease: auto
   ids:
     - 'none'


### PR DESCRIPTION
Rel: https://github.com/hashicorp/terraform-plugin-mux/pull/292

Will make sure our pre-releases don't get marked as latest, tested via the recent mux release:
- https://github.com/hashicorp/terraform-plugin-mux/actions/runs/13932069577
- https://github.com/hashicorp/terraform-plugin-mux/releases
- https://github.com/hashicorp/terraform-plugin-mux/releases/tag/v0.19.0-alpha.1

------

We don't have a planned pre-release for plugin-testing ATM, but this is the other Go module I could see us using this for, so want to merge this while I remember 😆 