### PR TITLE
helper/resource: easy access to state in `tfjson.State` form

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -68,7 +68,7 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 		var statePreDestroy *terraform.State
 		var err error
 		err = runProviderCommand(ctx, t, func() error {
-			statePreDestroy, err = getState(ctx, t, wd)
+			_, statePreDestroy, err = getState(ctx, t, wd)
 			if err != nil {
 				return err
 			}
@@ -447,18 +447,18 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 	}
 }
 
-func getState(ctx context.Context, t testing.T, wd *plugintest.WorkingDir) (*terraform.State, error) {
+func getState(ctx context.Context, t testing.T, wd *plugintest.WorkingDir) (*tfjson.State, *terraform.State, error) {
 	t.Helper()
 
 	jsonState, err := wd.State(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	state, err := shimStateFromJson(jsonState)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return state, nil
+	return jsonState, state, nil
 }
 
 func stateIsEmpty(state *terraform.State) bool {
@@ -573,7 +573,7 @@ func testIDRefresh(ctx context.Context, t testing.T, c TestCase, wd *plugintest.
 		if err != nil {
 			t.Fatalf("Error running terraform refresh: %s", err)
 		}
-		state, err = getState(ctx, t, wd)
+		_, state, err = getState(ctx, t, wd)
 		if err != nil {
 			return err
 		}

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -159,7 +159,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 			}
 
 			err = runProviderCommand(ctx, t, func() error {
-				stateBeforeApplication, err = getState(ctx, t, wd)
+				_, stateBeforeApplication, err = getState(ctx, t, wd)
 				if err != nil {
 					return err
 				}
@@ -200,7 +200,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 				var state *terraform.State
 
 				err := runProviderCommand(ctx, t, func() error {
-					state, err = getState(ctx, t, wd)
+					_, state, err = getState(ctx, t, wd)
 					if err != nil {
 						return err
 					}
@@ -384,7 +384,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 		var state *terraform.State
 
 		err = runProviderCommand(ctx, t, func() error {
-			state, err = getState(ctx, t, wd)
+			_, state, err = getState(ctx, t, wd)
 			if err != nil {
 				return err
 			}

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -58,10 +58,11 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 
 	// get state from check sequence
 	var state *terraform.State
+	var stateJSON *tfjson.State
 	var err error
 
 	err = runProviderCommand(ctx, t, func() error {
-		state, err = getState(ctx, t, wd)
+		stateJSON, state, err = getState(ctx, t, wd)
 		if err != nil {
 			return err
 		}
@@ -70,6 +71,9 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 	if err != nil {
 		t.Fatalf("Error getting state: %s", err)
 	}
+
+	// TODO: this statement is a placeholder -- it simply prevents stateJSON from being unused
+	logging.HelperResourceTrace(ctx, fmt.Sprintf("State before import: values %v", stateJSON.Values != nil))
 
 	// Determine the ID to import
 	var importId string
@@ -230,7 +234,7 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 
 	var importState *terraform.State
 	err = runProviderCommand(ctx, t, func() error {
-		importState, err = getState(ctx, t, importWd)
+		_, importState, err = getState(ctx, t, importWd)
 		if err != nil {
 			return err
 		}

--- a/helper/resource/testing_new_refresh_state.go
+++ b/helper/resource/testing_new_refresh_state.go
@@ -22,7 +22,7 @@ func testStepNewRefreshState(ctx context.Context, t testing.T, wd *plugintest.Wo
 	var err error
 	// Explicitly ensure prior state exists before refresh.
 	err = runProviderCommand(ctx, t, func() error {
-		_, err = getState(ctx, t, wd)
+		_, _, err = getState(ctx, t, wd)
 		if err != nil {
 			return err
 		}
@@ -41,7 +41,7 @@ func testStepNewRefreshState(ctx context.Context, t testing.T, wd *plugintest.Wo
 
 	var refreshState *terraform.State
 	err = runProviderCommand(ctx, t, func() error {
-		refreshState, err = getState(ctx, t, wd)
+		_, refreshState, err = getState(ctx, t, wd)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Internally, `resource.getState` trades a `tfjson.State` struct for a `terraform.InstanceState` struct. As discussed in https://github.com/hashicorp/terraform-plugin-testing/pull/467#discussion_r2014837932, it would be super helpful to operate on the  `tfjson` struct  without translation.

This pull request adds a return value to this unexported function. So this PR is a refactoring with no functional changes. I've added one logging statement to make the compiler and linter happy that there are no unused variables or parameters.