### PR TITLE
helper/resource: refine config-building for plannable import tests

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -109,7 +109,7 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 
 	logging.HelperResourceTrace(ctx, fmt.Sprintf("Using import identifier: %s", importId))
 
-	// Append to previous step config unless using ConfigFile or ConfigDirectory
+	// Append to previous step config unless using explicit inline Config, or ConfigFile, or ConfigDirectory
 	if testStepConfig == nil && step.ConfigFile == nil && step.ConfigDirectory == nil {
 		logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")
 		importConfig := cfgRaw

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -110,12 +110,9 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 	logging.HelperResourceTrace(ctx, fmt.Sprintf("Using import identifier: %s", importId))
 
 	// Append to previous step config unless using ConfigFile or ConfigDirectory
-	if testStepConfig == nil || step.Config != "" {
-		importConfig := step.Config
-		if importConfig == "" {
-			logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")
-			importConfig = cfgRaw
-		}
+	if testStepConfig == nil && step.ConfigFile == nil && step.ConfigDirectory == nil {
+		logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")
+		importConfig := cfgRaw
 
 		if kind.plannable() {
 			importConfig = appendImportBlock(importConfig, resourceName, importId)


### PR DESCRIPTION
This change allows explict inline Terraform configuration in an `ImportState` test step. In a newly-added test, we have a scenario where it's useful to the test author to write their own import block, without resorting to `ConfigFile` or `ConfigDirectory`.

This change also adds a test to cover the use of external providers with plannable import tests.