### PR TITLE
Add `AdditionalCLIOptions.PlanOptions.NoRefresh` to test `terraform plan -refresh=false`

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250421-145039.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250421-145039.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Adds `AdditionalCLIOptions.PlanOptions.NoRefresh` to test `terraform plan -refresh=false`
+time: 2025-04-21T14:50:39.764057-04:00
+custom:
+    Issue: "490"

--- a/helper/resource/additional_cli_options.go
+++ b/helper/resource/additional_cli_options.go
@@ -23,4 +23,7 @@ type ApplyOptions struct {
 type PlanOptions struct {
 	// AllowDeferral will pass the experimental `-allow-deferral` flag to the plan command.
 	AllowDeferral bool
+
+	// NoRefresh will pass the `-refresh=false` flag to the plan command.
+	NoRefresh bool
 }

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -108,8 +108,13 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 				opts = append(opts, tfexec.Destroy(true))
 			}
 
-			if c.AdditionalCLIOptions != nil && c.AdditionalCLIOptions.Plan.AllowDeferral {
-				opts = append(opts, tfexec.AllowDeferral(true))
+			if c.AdditionalCLIOptions != nil {
+				if c.AdditionalCLIOptions.Plan.AllowDeferral {
+					opts = append(opts, tfexec.AllowDeferral(true))
+				}
+				if c.AdditionalCLIOptions.Plan.NoRefresh {
+					opts = append(opts, tfexec.Refresh(false))
+				}
 			}
 
 			return wd.CreatePlan(ctx, opts...)
@@ -250,8 +255,13 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 			opts = append(opts, tfexec.Destroy(true))
 		}
 
-		if c.AdditionalCLIOptions != nil && c.AdditionalCLIOptions.Plan.AllowDeferral {
-			opts = append(opts, tfexec.AllowDeferral(true))
+		if c.AdditionalCLIOptions != nil {
+			if c.AdditionalCLIOptions.Plan.AllowDeferral {
+				opts = append(opts, tfexec.AllowDeferral(true))
+			}
+			if c.AdditionalCLIOptions.Plan.NoRefresh {
+				opts = append(opts, tfexec.Refresh(false))
+			}
 		}
 
 		return wd.CreatePlan(ctx, opts...)
@@ -319,8 +329,13 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 			}
 		}
 
-		if c.AdditionalCLIOptions != nil && c.AdditionalCLIOptions.Plan.AllowDeferral {
-			opts = append(opts, tfexec.AllowDeferral(true))
+		if c.AdditionalCLIOptions != nil {
+			if c.AdditionalCLIOptions.Plan.AllowDeferral {
+				opts = append(opts, tfexec.AllowDeferral(true))
+			}
+			if c.AdditionalCLIOptions.Plan.NoRefresh {
+				opts = append(opts, tfexec.Refresh(false))
+			}
 		}
 
 		return wd.CreatePlan(ctx, opts...)


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-plugin-testing/issues/489.

I see no value currently to adding the same to `ApplyOptions`.