### PR TITLE
experimental: faster tfversion tests

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -131,6 +131,22 @@ func TestMain(m interface {
 		}
 	} else {
 		exitCode := m.Run()
+
+		tempDir := os.Getenv(plugintest.EnvTfAccTempDir)
+		if tempDir == "" {
+			tempDir = os.TempDir()
+		}
+		pathParts := []string{
+			strings.TrimRight(tempDir, string(os.PathSeparator)),
+			"plugintest-terraform",
+			strconv.Itoa(os.Getpid()),
+		}
+		tfDir := strings.Join(pathParts, string(os.PathSeparator))
+		if err := os.RemoveAll(tfDir); err != nil {
+			log.Printf("[WARN] Failed to remove temporary directory for Terraform CLI: %s", err)
+
+		}
+
 		os.Exit(exitCode)
 	}
 }

--- a/internal/logging/environment_variables.go
+++ b/internal/logging/environment_variables.go
@@ -20,4 +20,5 @@ const (
 	// unset.
 	EnvTfLogSdkHelperResource = "TF_LOG_SDK_HELPER_RESOURCE"
 
+	EnvTfLogInstaller = "TF_LOG_INSTALLER"
 )

--- a/internal/logging/helper_resource.go
+++ b/internal/logging/helper_resource.go
@@ -12,6 +12,7 @@ import (
 const (
 	// SubsystemHelperResource is the tfsdklog subsystem name for helper/resource.
 	SubsystemHelperResource = "helper_resource"
+	SubsystemInstall        = "install"
 )
 
 // HelperResourceTrace emits a helper/resource subsystem log at TRACE level.

--- a/internal/plugintest/helper.go
+++ b/internal/plugintest/helper.go
@@ -110,14 +110,17 @@ func (h *Helper) Close() error {
 		return nil
 	}
 
+	return os.RemoveAll(h.baseDir)
+}
+
+func (h *Helper) CloseExecDir() error {
 	if h.execTempDir != "" {
 		err := os.RemoveAll(h.execTempDir)
 		if err != nil {
 			return err
 		}
 	}
-
-	return os.RemoveAll(h.baseDir)
+	return nil
 }
 
 // NewWorkingDir creates a new working directory for use in the implementation


### PR DESCRIPTION
For fun, not to be merged.

The `tfversion` tests are fairly unique in that they specify `"TF_ACC_TERRAFORM_VERSION"`. As a consequence, each of these tests downloads Terraform into its own temporary directory. This PR asks: what if they shared one temporary directory?

* Find Terraform binaries that we've already downloaded instead of repeatedly downloading them
* Read a `TF_LOG_INSTALLER` environment variable to log hc-install activity. Works best with a branch of hc-install that prepends log levels to logged messages.
* What if ... provider installation can also be de-duplicated?

Before:
```
$ time go test ./tfversion -count=1
ok  	github.com/hashicorp/terraform-plugin-testing/tfversion	223.588s
go test ./tfversion -count=1  45.66s user 29.61s system 33% cpu 3:44.32 total
```

After:
```
$ time go test ./tfversion -count=1
ok  	github.com/hashicorp/terraform-plugin-testing/tfversion	58.465s
go test ./tfversion -count=1  22.14s user 12.61s system 58% cpu 58.982 total
```