### PR TITLE
ResourceIdentity: Switch to using plan instead of applied state for asserting identity data

### DIFF
--- a/helper/resource/importstate/examplecloud_test.go
+++ b/helper/resource/importstate/examplecloud_test.go
@@ -596,3 +596,27 @@ func examplecloudResourceWithNullIdentityAttr() testprovider.Resource {
 		},
 	}
 }
+
+// This example resource, on update plans, will plan a different identity to test that
+// our testing framework assertions catch an identity that differs after import/refresh.
+func examplecloudResourceWithChangingIdentity() testprovider.Resource {
+	exampleCloudResource := examplecloudResource()
+
+	exampleCloudResource.PlanChangeFunc = func(ctx context.Context, req resource.PlanChangeRequest, resp *resource.PlanChangeResponse) {
+		// Only on update
+		if !req.PriorState.IsNull() && !req.ProposedNewState.IsNull() {
+			resp.PlannedIdentity = teststep.Pointer(tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"id": tftypes.String,
+					},
+				},
+				map[string]tftypes.Value{
+					"id": tftypes.NewValue(tftypes.String, "easteurope/someothervalue"),
+				},
+			))
+		}
+	}
+
+	return exampleCloudResource
+}

--- a/helper/resource/importstate/import_block_with_resource_identity_test.go
+++ b/helper/resource/importstate/import_block_with_resource_identity_test.go
@@ -119,6 +119,39 @@ func TestImportBlock_WithResourceIdentity_WithEveryType(t *testing.T) {
 	})
 }
 
+func TestImportBlock_WithResourceIdentity_ChangingIdentityError(t *testing.T) {
+	t.Parallel()
+
+	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0), // ImportBlockWithResourceIdentity requires Terraform 1.12.0 or later
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_container": examplecloudResourceWithChangingIdentity(),
+				},
+			}),
+		},
+		Steps: []r.TestStep{
+			{
+				Config: `
+				resource "examplecloud_container" "test" {
+					location = "westeurope"
+					name     = "somevalue"
+				}`,
+			},
+			{
+				ResourceName:    "examplecloud_container.test",
+				ImportState:     true,
+				ImportStateKind: r.ImportBlockWithResourceIdentity,
+				// The plan following the import will produce a different identity value then test step 1
+				ExpectError: regexp.MustCompile(`expected identity values map\[id:westeurope/somevalue\], got map\[id:easteurope/someothervalue\]`),
+			},
+		},
+	})
+}
+
 func TestImportBlock_WithResourceIdentity_RequiresVersion1_12_0(t *testing.T) {
 	t.Parallel()
 

--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -114,15 +114,6 @@ type providerFactories struct {
 	protov6 protov6ProviderFactories
 }
 
-func runProviderCommandApply(ctx context.Context, t testing.T, wd *plugintest.WorkingDir, factories *providerFactories) error {
-	t.Helper()
-
-	fn := func() error {
-		return wd.Apply(ctx)
-	}
-	return runProviderCommand(ctx, t, wd, factories, fn)
-}
-
 func runProviderCommandCreatePlan(ctx context.Context, t testing.T, wd *plugintest.WorkingDir, factories *providerFactories) error {
 	t.Helper()
 
@@ -130,23 +121,6 @@ func runProviderCommandCreatePlan(ctx context.Context, t testing.T, wd *pluginte
 		return wd.CreatePlan(ctx)
 	}
 	return runProviderCommand(ctx, t, wd, factories, fn)
-}
-
-func runProviderCommandGetStateJSON(ctx context.Context, t testing.T, wd *plugintest.WorkingDir, factories *providerFactories) (*tfjson.State, error) {
-	t.Helper()
-
-	var stateJSON *tfjson.State
-	fn := func() error {
-		var err error
-		stateJSON, err = wd.State(ctx)
-		return err
-	}
-	err := runProviderCommand(ctx, t, wd, factories, fn)
-	if err != nil {
-		return nil, err
-	}
-
-	return stateJSON, nil
 }
 
 func runProviderCommandSavedPlan(ctx context.Context, t testing.T, wd *plugintest.WorkingDir, factories *providerFactories) (*tfjson.Plan, error) {


### PR DESCRIPTION
The goal of the current assertion for identity imports is to ensure the prior saved identity is the same as the identity after import/refresh (i.e. the planned identity). This PR switches the previous logic from doing an apply, to using the `PlannedValues` of the no-op plan produced by a successful plannable import.

Luckily, `PlannedValues` also happens to be a `tfjson.StateValues`, similar to the `(tfjson.State).Values`, so there is a small refactor to do the comparison 👍🏻 