### PR TITLE
importstate: Fixed bug where prior test config is not used for `ConfigFile` or `ConfigDirectory`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250606-110444.yaml
+++ b/.changes/unreleased/BUG FIXES-20250606-110444.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'importstate: Fixed bug where prior test config is not used for `ConfigFile` or `ConfigDirectory`'
+body: 'helper/resource: Fixed bug with import state mode where prior test config is not used for `ConfigFile` or `ConfigDirectory`'
 time: 2025-06-06T11:04:44.925152-04:00
 custom:
     Issue: "516"

--- a/.changes/unreleased/BUG FIXES-20250606-110444.yaml
+++ b/.changes/unreleased/BUG FIXES-20250606-110444.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'importstate: Fixed bug where prior test config is not used for `ConfigFile` or `ConfigDirectory`'
+time: 2025-06-06T11:04:44.925152-04:00
+custom:
+    Issue: "516"

--- a/helper/resource/importstate/import_block_in_config_directory_test.go
+++ b/helper/resource/importstate/import_block_in_config_directory_test.go
@@ -38,7 +38,6 @@ func TestImportBlock_InConfigDirectory(t *testing.T) {
 				ResourceName:    "examplecloud_container.test",
 				ImportState:     true,
 				ImportStateKind: r.ImportBlockWithID,
-				ConfigDirectory: config.StaticDirectory(`testdata/2`),
 			},
 		},
 	})

--- a/helper/resource/importstate/import_block_in_config_file_test.go
+++ b/helper/resource/importstate/import_block_in_config_file_test.go
@@ -38,7 +38,6 @@ func TestImportBlock_InConfigFile(t *testing.T) {
 				ResourceName:    "examplecloud_container.test",
 				ImportState:     true,
 				ImportStateKind: r.ImportBlockWithID,
-				ConfigFile:      config.StaticFile(`testdata/2/examplecloud_container.tf`),
 			},
 		},
 	})

--- a/helper/resource/importstate/import_command_with_id_test.go
+++ b/helper/resource/importstate/import_command_with_id_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/datasource"
@@ -190,6 +191,60 @@ func TestImportCommand_ImportStateVerify(t *testing.T) {
 			},
 			{
 				ResourceName:      "examplecloud_thing.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestImportCommand_InConfigFile(t *testing.T) {
+	t.Parallel()
+
+	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_container": examplecloudResource(),
+				},
+			}),
+		},
+		Steps: []r.TestStep{
+			{
+				ConfigFile: config.StaticFile(`testdata/1/examplecloud_container.tf`),
+			},
+			{
+				ResourceName:      "examplecloud_container.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestImportCommand_InConfigDirectory(t *testing.T) {
+	t.Parallel()
+
+	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_container": examplecloudResource(),
+				},
+			}),
+		},
+		Steps: []r.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory(`testdata/1`),
+			},
+			{
+				ResourceName:      "examplecloud_container.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -118,13 +118,13 @@ func testStepNewImportState(ctx context.Context, t testing.T, helper *plugintest
 
 	// If the current import state test step doesn't have configuration, use the prior test step config
 	if testStepConfig == nil {
+		if priorStepCfg == nil {
+			t.Fatal("Cannot import state with no specified config")
+		}
+
 		logging.HelperResourceTrace(ctx, "Using prior TestStep Config for import")
 
 		testStepConfig = priorStepCfg
-	}
-
-	if testStepConfig == nil {
-		t.Fatal("Cannot import state with no specified config")
 	}
 
 	switch {


### PR DESCRIPTION
## Related Issue

Closes #516
Supersedes #519 

## Description

#516 was a regression split across two PRs so it was a little tough to catch, as well as the behavior of `teststep.Config` is not obvious:
- https://github.com/hashicorp/terraform-plugin-testing/pull/442
	- Removed `teststep.Config` usage in favor of a string, however, the original `mergedConfig` is actually ignored when creating a new `teststep.Config`, which is confusing, but would essentially result in a `ConfigFile/Directory` test step being shaved down into just a string that has a `required_providers` block.
- https://github.com/hashicorp/terraform-plugin-testing/pull/494
	- Removed the check for reusing a prior test step config, because it was checking a value that was always populated (either with real config via `step.Config` or just a shaved down `required_providers` block via `step.ConfigFile/Directory`)

This PR reintroduces the usage of a `teststep.Config` over a raw string, adjusts some of the existing tests to cover this scenario, and adds a new one for the command import mode.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
