### PR TITLE
query: update `ExpectLength` behaviour to support multiple list blocks

### DIFF
--- a/helper/resource/query/query_checks.go
+++ b/helper/resource/query/query_checks.go
@@ -25,6 +25,8 @@ func RunQueryChecks(ctx context.Context, t testing.T, query []tfjson.LogMsg, que
 	}
 
 	found := make([]tfjson.ListResourceFoundData, 0)
+	summaries := make([]tfjson.ListCompleteData, 0)
+	// summary can be removed when the deprecated QuerySummary field is removed from CheckQueryRequest
 	summary := tfjson.ListCompleteData{}
 
 	for _, msg := range query {
@@ -32,6 +34,7 @@ func RunQueryChecks(ctx context.Context, t testing.T, query []tfjson.LogMsg, que
 		case tfjson.ListResourceFoundMessage:
 			found = append(found, v.ListResourceFound)
 		case tfjson.ListCompleteMessage:
+			summaries = append(summaries, v.ListComplete)
 			summary = v.ListComplete
 			// TODO diagnostics and errors?
 		default:
@@ -51,8 +54,9 @@ func RunQueryChecks(ctx context.Context, t testing.T, query []tfjson.LogMsg, que
 		}
 		resp := querycheck.CheckQueryResponse{}
 		queryCheck.CheckQuery(ctx, querycheck.CheckQueryRequest{
-			Query:        reqQueryData,
-			QuerySummary: &summary,
+			Query:          reqQueryData,
+			QuerySummary:   &summary,
+			QuerySummaries: summaries,
 		}, &resp)
 
 		result = append(result, resp.Error)

--- a/querycheck/expect_result_length_exact.go
+++ b/querycheck/expect_result_length_exact.go
@@ -6,6 +6,7 @@ package querycheck
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 var _ QueryResultCheck = expectLength{}
@@ -17,13 +18,34 @@ type expectLength struct {
 
 // CheckQuery implements the query check logic.
 func (e expectLength) CheckQuery(_ context.Context, req CheckQueryRequest, resp *CheckQueryResponse) {
-	if req.QuerySummary == nil {
+	if req.QuerySummary == nil && req.QuerySummaries == nil {
 		resp.Error = fmt.Errorf("no query summary information available")
 		return
 	}
 
-	if e.check != req.QuerySummary.Total {
-		resp.Error = fmt.Errorf("number of found resources %v - expected but got %v.", e.check, req.QuerySummary.Total)
+	total := 0
+	for _, summary := range req.QuerySummaries {
+		// To support query tests where for_each is used to construct the list blocks dynamically (e.g. with child resources) we allow
+		// specifying a trailing '*' to indicate that we should be looking for multiple summaries
+
+		if !strings.HasSuffix(e.resourceAddress, "*") {
+			if strings.EqualFold(strings.TrimPrefix(summary.Address, "list."), e.resourceAddress) {
+				if e.check != summary.Total {
+					resp.Error = fmt.Errorf("number of found resources for %s - expected %v but got %v", e.resourceAddress, e.check, summary.Total)
+				}
+				// It's been found and checked, we can exit
+				return
+			}
+		} else {
+			// when using for_each summary.Address returns as `list.{resource_name}.{resource_label}[{each.key}]`
+			if strings.HasPrefix(strings.TrimPrefix(summary.Address, "list."), strings.TrimSuffix(e.resourceAddress, "*")) {
+				total = total + summary.Total
+			}
+		}
+	}
+
+	if total != e.check {
+		resp.Error = fmt.Errorf("number of found resources for %s - expected %v but got %v", e.resourceAddress, e.check, total)
 		return
 	}
 }

--- a/querycheck/expect_result_length_exact_test.go
+++ b/querycheck/expect_result_length_exact_test.go
@@ -73,6 +73,63 @@ func TestResultLengthExact(t *testing.T) {
 	})
 }
 
+func TestResultLengthMultiplePattern(t *testing.T) {
+	t.Parallel()
+
+	r.UnitTest(t, r.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+				ListResources: map[string]testprovider.ListResource{
+					"examplecloud_containerette": examplecloudListResource(),
+				},
+				Resources: map[string]testprovider.Resource{
+					"examplecloud_containerette": examplecloudResource(),
+				},
+			}),
+		},
+		Steps: []r.TestStep{
+			{ // config mode step 1 needs tf file with terraform providers block
+				// this step should provision all the resources that the query is support to list
+				// for simplicity we're only "provisioning" one here
+				Config: `
+				resource "examplecloud_containerette" "primary" {
+					name                = "banana"
+					resource_group_name = "foo"
+					location  			= "westeurope"
+			
+					instances = 5
+				}`,
+			},
+			{
+				Query: true,
+				Config: `
+				provider "examplecloud" {}
+				list "examplecloud_containerette" "test" {
+					provider = examplecloud
+			
+					config {
+						resource_group_name = "foo"
+ 					}
+				}
+				list "examplecloud_containerette" "test2" {
+					provider = examplecloud
+			
+					config {
+						resource_group_name = "bar"
+ 					}
+				}
+				`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("examplecloud_containerette.test*", 12),
+				},
+			},
+		},
+	})
+}
+
 func TestResultLengthExact_WrongAmount(t *testing.T) {
 	t.Parallel()
 

--- a/querycheck/query_check.go
+++ b/querycheck/query_check.go
@@ -32,7 +32,13 @@ type CheckQueryRequest struct {
 	Query []tfjson.ListResourceFoundData
 
 	// QuerySummary contains a summary of the completed query operation
+	//
+	// Deprecated: QuerySummary contains incomplete information when multiple list blocks are specified in a query.
+	// QuerySummaries should be used instead.
 	QuerySummary *tfjson.ListCompleteData
+
+	// QuerySummaries contains the summaries of each list block in a query operation
+	QuerySummaries []tfjson.ListCompleteData
 }
 
 // CheckQueryResponse is a response to an invoke of the CheckQuery function.


### PR DESCRIPTION
## Related Issue

Resource Test Config
```
resource "parent" "test1" {
  name = "parent1"
}

resource "parent" "test2" {
  name = "parent2"
}

resource "child" "test1" {
  count = 3

  name        = "child1-${count.index}"
  parent_name = parent.test1.name
}

resource "child" "test2" {
  count = 2

  name        = "child2-${count.index}"
  parent_name = parent.test2.name
}
```

List Test Config
```
list "parent" "test" {
  provider = thing

  config {
    some_grouping = "I am grandparent"
  }
}

list "child" "test" {
  for_each = toset([for parent in list.parent.test.data : parent.state.name])

  provider = thing

  config {
    parent_name = each.key
  }
}
```

Failing ExpectLength Checks
```
querycheck.ExpectLength("parent.test", 2) // compares against a count of 3 and fails
querycheck.ExpectLength("child.test", 5) // compares against a count of 3 and fails
```

Example derived from https://github.com/hashicorp/terraform-provider-azurerm/blob/527c291f1dd717cab9bc7c36bfc8a4602b3f7708/internal/services/network/subnet_resource_list_test.go

## Description

This PR proposes how we could update the behaviour of the `ExpectLength` check without causing disruption through a breaking change or through the replacement of this check.

The config examples above highlight several shortcomings in the current design of the `ExpectLength` querycheck
1. Users cannot construct a query test that can check the expected number of found resources for different types of list resources
2. Multiple list resources of the same type that are created dynamically with `for_each` cannot be reliably checked

Several changes have been made to support both use cases, the second case in particular will likely be a highly common and popular way for users to query child resources.

I've chosen to deprecate the existing `QuerySummary` property in the `CheckQueryRequest` and introduced a `QuerySummaries` that will collect all available `tjson.ListCompleteMessages` from the query command.

The `ExpectLength` check has been updated to find the correct summary based on the provided resource address for validating the count.

Furthermore we would need to provide a means for providers to indicate that we're computing the sum of multiple summaries, thus the suggestion to support the addition of a  trailing `*` on the resource address specified in the query check e.g. `querycheck.ExpectLength("child.test*", 5)`

Whilst it isn't the most robust solution, it's a non-breaking option.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
