### PR TITLE
helper/resource: add missing `refreshes` for `refreshAfterApply` + add missing `DestroyPlan`

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -471,7 +471,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 		logging.HelperResourceDebug(ctx, "Called TestCase PostApplyFunc")
 	}
 
-	if refreshAfterApply && !step.Destroy && !step.PlanOnly {
+	if refreshAfterApply && !step.Destroy && !step.PlanOnly && !step.ExpectNonEmptyPlan {
 		if len(c.Steps) > stepIndex+1 {
 			// If the next step is a refresh, then we have no need to refresh here
 			if !c.Steps[stepIndex+1].RefreshState {


### PR DESCRIPTION
# Related Issue

This PR addresses some missing cases that we had missed when working on:
- https://github.com/hashicorp/terraform-plugin-testing/pull/496

This PR would address the last failing tests here:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/16144

# Description

Each commit in this PR represents a fix for a specific case:

## https://github.com/hashicorp/terraform-plugin-testing/commit/4ea556603a939cbb2c0bc4daef665c92efd635f2 - Fixes `Error: Saved Plan is Stale`

a refresh occurred in [step.Destroy](https://github.com/BBBmau/terraform-plugin-testing/blob/e3174840a6e94d9a839c4c30f237a81381779c44/helper/resource/testing_new_config.go#L157-L196) right after a plan had been created, the following apply relied on the first plan that occurs in `testStepNewConfig` but since a refresh occurs we get into a scenario where the snapshots are not in sync leading to the saved plan is stale error. 

Martin did a nice write-up on this a few years back that i [found](https://discuss.hashicorp.com/t/question-on-error-saved-plan-is-stale/52912/2#:~:text=When%20Terraform%20saves,you%20run%20apply.the). 

The [fix](https://github.com/BBBmau/terraform-plugin-testing/blob/e4aea5a9f308abdb3bc8a40877ebcf447834567a/helper/resource/testing_new_config.go#L186-L196) was to add a Destroy plan before the apply to ensure that states are synced up between plan and apply for destroy. This case occurs when attempting to perform a destroy with a check, the google provider has two occurrences of this.

## https://github.com/hashicorp/terraform-plugin-testing/commit/28c63bff44134e5bb5af251192351d63d3a49cb1 - Revert non-refresh on plan when `refreshAfterApply` is `true`

This updates the post-apply non-refresh plan to rely on the `refreshAfterApply` variable instead of the explicit [Refresh(false)](https://github.com/hashicorp/terraform-plugin-testing/blame/08dd5f02ff7aff2d6dcc60cee1aa446c31637f69/helper/resource/testing_new_config.go#L259-L261) which was applied to within the same PR that removes separate refresh on plan. This would resolve the test cases such as [TestAccArtifactRegistryRepository_cleanup](https://github.com/hashicorp/terraform-provider-google/blob/ce0407866b5d6620e68378fcc38ec1d04840c21d/google/services/artifactregistry/resource_artifact_registry_repository_test.go#L157-L185) which passed prior to 1.6.0

## https://github.com/hashicorp/terraform-plugin-testing/commit/e3174840a6e94d9a839c4c30f237a81381779c44 - prevent a `refreshAfterApply` when `ExpectNonEmptyPlan: true`

https://github.com/hashicorp/terraform-plugin-testing/pull/496 introduced a bug which caused certain tests such as `TestAccBigQueryTable_schemaColumnDropWithRowAccessPolicy` to pass. 

Adding `!step.ExpectNonEmptyPlan` as part of the `refreshAfterApply` condition resolves the failng test which previously was passing in `1.5.1`, we now prevent `refreshAfterApply` from occurring when `!step.Destroy && !step.PlanOnly && !step.ExpectNonEmptyPlan`