### PR TITLE
Add diagcheck package for testing deprecation warnings

### DIFF
--- a/diagcheck/diagnostic_check.go
+++ b/diagcheck/diagnostic_check.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck
+
+import (
+	"context"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// DiagnosticCheck defines an interface for implementing test logic that checks diagnostics and then returns an error
+// if the diagnostics do not match what is expected.
+type DiagnosticCheck interface {
+	// CheckDiagnostics should perform the diagnostic check.
+	CheckDiagnostics(context.Context, CheckDiagnosticsRequest, *CheckDiagnosticsResponse)
+}
+
+// CheckDiagnosticsRequest is a request for an invoke of the CheckDiagnostics function.
+type CheckDiagnosticsRequest struct {
+	// Diagnostics represents diagnostics from terraform validate, containing errors and warnings.
+	Diagnostics []tfjson.Diagnostic
+}
+
+// CheckDiagnosticsResponse is a response to an invoke of the CheckDiagnostics function.
+type CheckDiagnosticsResponse struct {
+	// Error is used to report the failure of a diagnostic check assertion and is combined with other DiagnosticCheck errors
+	// to be reported as a test failure.
+	Error error
+}

--- a/diagcheck/doc.go
+++ b/diagcheck/doc.go
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package diagcheck contains the diagnostic check interface, request/response structs, and common diagnostic check implementations
+// for validating Terraform diagnostics (errors and warnings) in acceptance tests.
+package diagcheck

--- a/diagcheck/expect_diagnostic.go
+++ b/diagcheck/expect_diagnostic.go
@@ -1,0 +1,52 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck
+
+import (
+	"context"
+	"fmt"
+)
+
+var _ DiagnosticCheck = expectDiagnostic{}
+
+type expectDiagnostic struct {
+	severity string
+	summary  string
+	detail   string
+}
+
+// CheckDiagnostics implements the diagnostic check logic.
+func (e expectDiagnostic) CheckDiagnostics(ctx context.Context, req CheckDiagnosticsRequest, resp *CheckDiagnosticsResponse) {
+	for _, diag := range req.Diagnostics {
+		if string(diag.Severity) == e.severity &&
+			diag.Summary == e.summary &&
+			diag.Detail == e.detail {
+			// Found matching diagnostic
+			return
+		}
+	}
+
+	// Diagnostic not found
+	resp.Error = fmt.Errorf("expected %s diagnostic not found: summary=%q detail=%q", e.severity, e.summary, e.detail)
+}
+
+// ExpectDiagnostic returns a diagnostic check that asserts that a specific diagnostic exists with the given
+// severity, summary, and detail. The severity should be "error" or "warning".
+func ExpectDiagnostic(severity, summary, detail string) DiagnosticCheck {
+	return expectDiagnostic{
+		severity: severity,
+		summary:  summary,
+		detail:   detail,
+	}
+}
+
+// ExpectWarning returns a diagnostic check that asserts that a specific warning diagnostic exists with the given
+// summary and detail. This is a convenience wrapper for ExpectDiagnostic with severity="warning".
+func ExpectWarning(summary, detail string) DiagnosticCheck {
+	return expectDiagnostic{
+		severity: "warning",
+		summary:  summary,
+		detail:   detail,
+	}
+}

--- a/diagcheck/expect_diagnostic_count.go
+++ b/diagcheck/expect_diagnostic_count.go
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck
+
+import (
+	"context"
+	"fmt"
+)
+
+var _ DiagnosticCheck = expectDiagnosticCount{}
+
+type expectDiagnosticCount struct {
+	severity string
+	count    int
+}
+
+// CheckDiagnostics implements the diagnostic check logic.
+func (e expectDiagnosticCount) CheckDiagnostics(ctx context.Context, req CheckDiagnosticsRequest, resp *CheckDiagnosticsResponse) {
+	actualCount := 0
+
+	for _, diag := range req.Diagnostics {
+		if string(diag.Severity) == e.severity {
+			actualCount++
+		}
+	}
+
+	if actualCount != e.count {
+		resp.Error = fmt.Errorf("expected %d %s diagnostic(s), got %d", e.count, e.severity, actualCount)
+	}
+}
+
+// ExpectDiagnosticCount returns a diagnostic check that asserts that there are exactly the specified number of
+// diagnostics with the given severity. The severity should be "error" or "warning".
+func ExpectDiagnosticCount(severity string, count int) DiagnosticCheck {
+	return expectDiagnosticCount{
+		severity: severity,
+		count:    count,
+	}
+}
+
+// ExpectWarningCount returns a diagnostic check that asserts that there are exactly the specified number of
+// warning diagnostics. This is a convenience wrapper for ExpectDiagnosticCount with severity="warning".
+func ExpectWarningCount(count int) DiagnosticCheck {
+	return expectDiagnosticCount{
+		severity: "warning",
+		count:    count,
+	}
+}

--- a/diagcheck/expect_diagnostic_count_test.go
+++ b/diagcheck/expect_diagnostic_count_test.go
@@ -1,0 +1,217 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck_test
+
+import (
+	"context"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/diagcheck"
+)
+
+func TestExpectDiagnosticCount_ZeroCount(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnosticCount("warning", 0)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error for zero count, got: %v", resp.Error)
+	}
+}
+
+func TestExpectDiagnosticCount_CorrectCount(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnosticCount("warning", 2)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 1",
+				Detail:   "Detail 1",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 2",
+				Detail:   "Detail 2",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error for correct count, got: %v", resp.Error)
+	}
+}
+
+func TestExpectDiagnosticCount_IncorrectCount_TooFew(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnosticCount("warning", 3)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 1",
+				Detail:   "Detail 1",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for incorrect count (too few), got nil")
+	}
+}
+
+func TestExpectDiagnosticCount_IncorrectCount_TooMany(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnosticCount("error", 1)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Error 1",
+				Detail:   "Detail 1",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Error 2",
+				Detail:   "Detail 2",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for incorrect count (too many), got nil")
+	}
+}
+
+func TestExpectDiagnosticCount_OnlyCountsMatchingSeverity(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnosticCount("warning", 2)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 1",
+				Detail:   "Detail 1",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Error 1",
+				Detail:   "Detail 1",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 2",
+				Detail:   "Detail 2",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Error 2",
+				Detail:   "Detail 2",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error when counting only matching severity, got: %v", resp.Error)
+	}
+}
+
+func TestExpectWarningCount_Zero(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectWarningCount(0)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Error 1",
+				Detail:   "Detail 1",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error for zero warning count with errors present, got: %v", resp.Error)
+	}
+}
+
+func TestExpectWarningCount_Correct(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectWarningCount(3)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 1",
+				Detail:   "Detail 1",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 2",
+				Detail:   "Detail 2",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 3",
+				Detail:   "Detail 3",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error for correct warning count, got: %v", resp.Error)
+	}
+}
+
+func TestExpectWarningCount_Incorrect(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectWarningCount(2)
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 1",
+				Detail:   "Detail 1",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for incorrect warning count, got nil")
+	}
+}

--- a/diagcheck/expect_diagnostic_test.go
+++ b/diagcheck/expect_diagnostic_test.go
@@ -1,0 +1,170 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck_test
+
+import (
+	"context"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/diagcheck"
+)
+
+func TestExpectDiagnostic_Found(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnostic("warning", "Test Summary", "Test Detail")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Test Summary",
+				Detail:   "Test Detail",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error when diagnostic found, got: %v", resp.Error)
+	}
+}
+
+func TestExpectDiagnostic_NotFound(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnostic("warning", "Expected Summary", "Expected Detail")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Different Summary",
+				Detail:   "Different Detail",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error when diagnostic not found, got nil")
+	}
+}
+
+func TestExpectDiagnostic_WrongSeverity(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnostic("error", "Test Summary", "Test Detail")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Test Summary",
+				Detail:   "Test Detail",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error when severity doesn't match, got nil")
+	}
+}
+
+func TestExpectDiagnostic_FoundAmongMultiple(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnostic("warning", "Second Warning", "Second Detail")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "First Warning",
+				Detail:   "First Detail",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Second Warning",
+				Detail:   "Second Detail",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "An Error",
+				Detail:   "Error Detail",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error when diagnostic found among multiple, got: %v", resp.Error)
+	}
+}
+
+func TestExpectDiagnostic_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectDiagnostic("warning", "Test Summary", "Test Detail")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error when diagnostic list is empty, got nil")
+	}
+}
+
+func TestExpectWarning_Found(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectWarning("Deprecation Warning", "Use new_field instead")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Deprecation Warning",
+				Detail:   "Use new_field instead",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error when warning found, got: %v", resp.Error)
+	}
+}
+
+func TestExpectWarning_ErrorInsteadOfWarning(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectWarning("Test Summary", "Test Detail")
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Test Summary",
+				Detail:   "Test Detail",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error when severity is error instead of warning, got nil")
+	}
+}

--- a/diagcheck/expect_no_diagnostics.go
+++ b/diagcheck/expect_no_diagnostics.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+var _ DiagnosticCheck = expectNoDiagnostics{}
+
+type expectNoDiagnostics struct {
+	allowErrors   bool
+	allowWarnings bool
+}
+
+// CheckDiagnostics implements the diagnostic check logic.
+func (e expectNoDiagnostics) CheckDiagnostics(ctx context.Context, req CheckDiagnosticsRequest, resp *CheckDiagnosticsResponse) {
+	var result []error
+
+	for _, diag := range req.Diagnostics {
+		if diag.Severity == tfjson.DiagnosticSeverityError && !e.allowErrors {
+			result = append(result, fmt.Errorf("unexpected error diagnostic: %s - %s", diag.Summary, diag.Detail))
+		}
+		if diag.Severity == tfjson.DiagnosticSeverityWarning && !e.allowWarnings {
+			result = append(result, fmt.Errorf("unexpected warning diagnostic: %s - %s", diag.Summary, diag.Detail))
+		}
+	}
+
+	resp.Error = errors.Join(result...)
+}
+
+// ExpectNoDiagnostics returns a diagnostic check that asserts that there are no diagnostics (errors or warnings).
+// All diagnostics found will be aggregated and returned in a diagnostic check error.
+func ExpectNoDiagnostics() DiagnosticCheck {
+	return expectNoDiagnostics{
+		allowErrors:   false,
+		allowWarnings: false,
+	}
+}
+
+// ExpectNoWarnings returns a diagnostic check that asserts that there are no warning diagnostics.
+// Errors are allowed. All warnings found will be aggregated and returned in a diagnostic check error.
+func ExpectNoWarnings() DiagnosticCheck {
+	return expectNoDiagnostics{
+		allowErrors:   true,
+		allowWarnings: false,
+	}
+}
+
+// ExpectNoErrors returns a diagnostic check that asserts that there are no error diagnostics.
+// Warnings are allowed. All errors found will be aggregated and returned in a diagnostic check error.
+func ExpectNoErrors() DiagnosticCheck {
+	return expectNoDiagnostics{
+		allowErrors:   false,
+		allowWarnings: true,
+	}
+}

--- a/diagcheck/expect_no_diagnostics_test.go
+++ b/diagcheck/expect_no_diagnostics_test.go
@@ -1,0 +1,187 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package diagcheck_test
+
+import (
+	"context"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/diagcheck"
+)
+
+func TestExpectNoDiagnostics_NoDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoDiagnostics()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error, got: %v", resp.Error)
+	}
+}
+
+func TestExpectNoDiagnostics_WithWarning_Error(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoDiagnostics()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Test Warning",
+				Detail:   "This is a test warning",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for warning diagnostic, got nil")
+	}
+}
+
+func TestExpectNoDiagnostics_WithError_Error(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoDiagnostics()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Test Error",
+				Detail:   "This is a test error",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for error diagnostic, got nil")
+	}
+}
+
+func TestExpectNoDiagnostics_WithMultiple_Error(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoDiagnostics()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Warning 1",
+				Detail:   "First warning",
+			},
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Error 1",
+				Detail:   "First error",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for multiple diagnostics, got nil")
+	}
+}
+
+func TestExpectNoWarnings_NoWarnings(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoWarnings()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Test Error",
+				Detail:   "This is a test error",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error when only errors present, got: %v", resp.Error)
+	}
+}
+
+func TestExpectNoWarnings_WithWarning_Error(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoWarnings()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Test Warning",
+				Detail:   "This is a test warning",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for warning diagnostic, got nil")
+	}
+}
+
+func TestExpectNoErrors_NoErrors(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoErrors()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityWarning,
+				Summary:  "Test Warning",
+				Detail:   "This is a test warning",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error != nil {
+		t.Errorf("expected no error when only warnings present, got: %v", resp.Error)
+	}
+}
+
+func TestExpectNoErrors_WithError_Error(t *testing.T) {
+	t.Parallel()
+
+	check := diagcheck.ExpectNoErrors()
+	req := diagcheck.CheckDiagnosticsRequest{
+		Diagnostics: []tfjson.Diagnostic{
+			{
+				Severity: tfjson.DiagnosticSeverityError,
+				Summary:  "Test Error",
+				Detail:   "This is a test error",
+			},
+		},
+	}
+	resp := &diagcheck.CheckDiagnosticsResponse{}
+
+	check.CheckDiagnostics(context.Background(), req, resp)
+
+	if resp.Error == nil {
+		t.Error("expected error for error diagnostic, got nil")
+	}
+}

--- a/helper/resource/diagnostic_checks.go
+++ b/helper/resource/diagnostic_checks.go
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"context"
+	"errors"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/diagcheck"
+	"github.com/mitchellh/go-testing-interface"
+)
+
+func runDiagnosticChecks(ctx context.Context, t testing.T, diagnostics []tfjson.Diagnostic, diagChecks []diagcheck.DiagnosticCheck) error {
+	t.Helper()
+
+	var result []error
+
+	for _, diagCheck := range diagChecks {
+		resp := diagcheck.CheckDiagnosticsResponse{}
+		diagCheck.CheckDiagnostics(ctx, diagcheck.CheckDiagnosticsRequest{Diagnostics: diagnostics}, &resp)
+
+		result = append(result, resp.Error)
+	}
+
+	return errors.Join(result...)
+}

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/diagcheck"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -641,6 +642,14 @@ type TestStep struct {
 	// ConfigStateChecks allow assertions to be made against the state file during a Config (apply) test using a state check.
 	// Custom state checks can be created by implementing the [statecheck.StateCheck] interface, or by using a StateCheck implementation from the provided [statecheck] package.
 	ConfigStateChecks []statecheck.StateCheck
+
+	// ConfigValidateChecks runs diagnostic checks after terraform validate.
+	// This occurs after configuration is set and init is run, before plan/apply.
+	// Custom diagnostic checks can be created by implementing the [diagcheck.DiagnosticCheck] interface, or by using a DiagnosticCheck implementation from the provided [diagcheck] package.
+	//
+	// [diagcheck.DiagnosticCheck]: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/diagcheck#DiagnosticCheck
+	// [diagcheck]: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/diagcheck
+	ConfigValidateChecks []diagcheck.DiagnosticCheck
 
 	// QueryResultChecks allow assertions to be made against a collection of found resources that were returned by a query using a query check.
 	// Custom query checks can be created by implementing the [querycheck.QueryResultCheck] interface, or by using a QueryResultCheck implementation from the provided [querycheck] package.

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -103,6 +103,24 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 		return fmt.Errorf("Error setting config: %w", err)
 	}
 
+	// Run validation and diagnostic checks
+	if len(step.ConfigValidateChecks) > 0 {
+		var validateOutput *tfjson.ValidateOutput
+		err = runProviderCommand(ctx, t, wd, providers, func() error {
+			var err error
+			validateOutput, err = wd.Validate(ctx)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("Error running terraform validate: %w", err)
+		}
+
+		err = runDiagnosticChecks(ctx, t, validateOutput.Diagnostics, step.ConfigValidateChecks)
+		if err != nil {
+			return fmt.Errorf("Validation diagnostic check(s) failed:\n%w", err)
+		}
+	}
+
 	// If this step is a PlanOnly step, skip over this first Plan and
 	// subsequent Apply, and use the follow-up Plan that checks for
 	// permadiffs

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -524,6 +524,19 @@ func (wd *WorkingDir) Schemas(ctx context.Context) (*tfjson.ProviderSchemas, err
 	return providerSchemas, err
 }
 
+// Validate runs terraform validate and returns structured validation output.
+//
+// If validation cannot be executed, Validate returns an error.
+func (wd *WorkingDir) Validate(ctx context.Context) (*tfjson.ValidateOutput, error) {
+	logging.HelperResourceTrace(ctx, "Calling Terraform CLI validate command")
+
+	output, err := wd.tf.Validate(context.Background())
+
+	logging.HelperResourceTrace(ctx, "Called Terraform CLI validate command")
+
+	return output, err
+}
+
 func (wd *WorkingDir) Query(ctx context.Context) ([]tfjson.LogMsg, error) {
 	var messages []tfjson.LogMsg
 	var diags []tfjson.LogMsg


### PR DESCRIPTION
Introduces a new diagcheck package that enables provider developers to test
deprecation messages in acceptance tests. The package follows the established
plancheck/statecheck pattern and integrates with terraform validate command.

Key features:
- DiagnosticCheck interface for validating terraform diagnostics
- ExpectNoDiagnostics(), ExpectNoWarnings(), ExpectNoErrors() checks
- ExpectDiagnostic() and ExpectWarning() for specific diagnostic assertions
- ExpectDiagnosticCount() and ExpectWarningCount() for count validation
- ConfigValidateChecks field on TestStep for validation-time checks
- Validate() method on WorkingDir to execute terraform validate
- 100% test coverage with 23 unit tests

This addresses the need to test deprecation messages introduced across the
Terraform plugin ecosystem (terraform-plugin-framework#1276,
terraform-plugin-sdk#1553, terraform-core#38135).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Related Issue

Fixes # <!-- INSERT ISSUE NUMBER -->

## Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
