### PR TITLE
`v1.14.1` patch for `refreshAfterApply`

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -182,6 +182,17 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 			if err != nil {
 				return fmt.Errorf("Error retrieving pre-apply state: %w", err)
 			}
+
+			// Create Destroy Plan
+			err = runProviderCommand(ctx, t, wd, providers, func() error {
+				var opts []tfexec.PlanOption
+				opts = append(opts, tfexec.Destroy(true))
+
+				return wd.CreatePlan(ctx, opts...)
+			})
+			if err != nil {
+				return fmt.Errorf("Error running pre-apply plan: %w", err)
+			}
 		}
 
 		// Apply the diff, creating real resources
@@ -256,8 +267,11 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 
 	// do a plan
 	err = runProviderCommand(ctx, t, wd, providers, func() error {
-		opts := []tfexec.PlanOption{
-			tfexec.Refresh(false),
+		var opts []tfexec.PlanOption
+		if refreshAfterApply {
+			opts = append(opts, tfexec.Refresh(true))
+		} else {
+			opts = append(opts, tfexec.Refresh(false))
 		}
 		if step.Destroy {
 			opts = append(opts, tfexec.Destroy(true))
@@ -457,7 +471,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 		logging.HelperResourceDebug(ctx, "Called TestCase PostApplyFunc")
 	}
 
-	if refreshAfterApply && !step.Destroy && !step.PlanOnly {
+	if refreshAfterApply && !step.Destroy && !step.PlanOnly && !step.ExpectNonEmptyPlan {
 		if len(c.Steps) > stepIndex+1 {
 			// If the next step is a refresh, then we have no need to refresh here
 			if !c.Steps[stepIndex+1].RefreshState {

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -267,11 +267,8 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 
 	// do a plan
 	err = runProviderCommand(ctx, t, wd, providers, func() error {
-		var opts []tfexec.PlanOption
-		if refreshAfterApply {
-			opts = append(opts, tfexec.Refresh(true))
-		} else {
-			opts = append(opts, tfexec.Refresh(false))
+		opts := []tfexec.PlanOption{
+			tfexec.Refresh(false),
 		}
 		if step.Destroy {
 			opts = append(opts, tfexec.Destroy(true))


### PR DESCRIPTION
## Related Issue

Since using the latest release involves introducing a new RPC, this patch is for including the necessary `refreshAfterApply` changes without introducing the breaking change of the new RPC

## Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
