### PR TITLE
Patch v1.14.1

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260330-171116.yaml
+++ b/.changes/unreleased/BUG FIXES-20260330-171116.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "Backport: Remove the redundant post-apply refresh triggered by resource/refreshAfterApply so acceptance tests avoid an extra refresh cycle."
+time: 2026-03-30T17:11:16.532832+02:00
+custom:
+    Issue: "641"

--- a/helper/resource/testcase_providers.go
+++ b/helper/resource/testcase_providers.go
@@ -20,26 +20,26 @@ func (c TestCase) providerConfig(_ context.Context, skipProviderBlock bool) stri
 	//      is being used and not the others, but leaving it here just in case
 	//      it does have a special purpose that wasn't being unit tested prior.
 	for name := range c.Providers {
-		providerBlocks.WriteString(fmt.Sprintf("provider %q {}\n", name))
+		fmt.Fprintf(&providerBlocks, "provider %q {}\n", name)
 	}
 
 	for name, externalProvider := range c.ExternalProviders {
 		if !skipProviderBlock {
-			providerBlocks.WriteString(fmt.Sprintf("provider %q {}\n", name))
+			fmt.Fprintf(&providerBlocks, "provider %q {}\n", name)
 		}
 
 		if externalProvider.Source == "" && externalProvider.VersionConstraint == "" {
 			continue
 		}
 
-		requiredProviderBlocks.WriteString(fmt.Sprintf("    %s = {\n", name))
+		fmt.Fprintf(&requiredProviderBlocks, "    %s = {\n", name)
 
 		if externalProvider.Source != "" {
-			requiredProviderBlocks.WriteString(fmt.Sprintf("      source = %q\n", externalProvider.Source))
+			fmt.Fprintf(&requiredProviderBlocks, "      source = %q\n", externalProvider.Source)
 		}
 
 		if externalProvider.VersionConstraint != "" {
-			requiredProviderBlocks.WriteString(fmt.Sprintf("      version = %q\n", externalProvider.VersionConstraint))
+			fmt.Fprintf(&requiredProviderBlocks, "      version = %q\n", externalProvider.VersionConstraint)
 		}
 
 		requiredProviderBlocks.WriteString("    }\n")

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -182,6 +182,17 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 			if err != nil {
 				return fmt.Errorf("Error retrieving pre-apply state: %w", err)
 			}
+
+			// Create Destroy Plan
+			err = runProviderCommand(ctx, t, wd, providers, func() error {
+				var opts []tfexec.PlanOption
+				opts = append(opts, tfexec.Destroy(true))
+
+				return wd.CreatePlan(ctx, opts...)
+			})
+			if err != nil {
+				return fmt.Errorf("Error running pre-apply plan: %w", err)
+			}
 		}
 
 		// Apply the diff, creating real resources
@@ -256,8 +267,11 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 
 	// do a plan
 	err = runProviderCommand(ctx, t, wd, providers, func() error {
-		opts := []tfexec.PlanOption{
-			tfexec.Refresh(false),
+		var opts []tfexec.PlanOption
+		if refreshAfterApply {
+			opts = append(opts, tfexec.Refresh(true))
+		} else {
+			opts = append(opts, tfexec.Refresh(false))
 		}
 		if step.Destroy {
 			opts = append(opts, tfexec.Destroy(true))
@@ -457,7 +471,7 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 		logging.HelperResourceDebug(ctx, "Called TestCase PostApplyFunc")
 	}
 
-	if refreshAfterApply && !step.Destroy && !step.PlanOnly {
+	if refreshAfterApply && !step.Destroy && !step.PlanOnly && !step.ExpectNonEmptyPlan {
 		if len(c.Steps) > stepIndex+1 {
 			// If the next step is a refresh, then we have no need to refresh here
 			if !c.Steps[stepIndex+1].RefreshState {

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -267,11 +267,8 @@ func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugint
 
 	// do a plan
 	err = runProviderCommand(ctx, t, wd, providers, func() error {
-		var opts []tfexec.PlanOption
-		if refreshAfterApply {
-			opts = append(opts, tfexec.Refresh(true))
-		} else {
-			opts = append(opts, tfexec.Refresh(false))
+		opts := []tfexec.PlanOption{
+			tfexec.Refresh(false),
 		}
 		if step.Destroy {
 			opts = append(opts, tfexec.Destroy(true))

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -423,11 +423,11 @@ func appendImportBlock(config teststep.Config, resourceName string, importID str
 
 func appendImportBlockWithIdentity(config teststep.Config, resourceName string, identityValues map[string]any) teststep.Config {
 	configBuilder := strings.Builder{}
-	configBuilder.WriteString(fmt.Sprintf(``+"\n"+
+	fmt.Fprintf(&configBuilder, ``+"\n"+
 		`import {`+"\n"+
 		`	to = %s`+"\n"+
 		`	identity = {`+"\n",
-		resourceName))
+		resourceName)
 
 	for k, v := range identityValues {
 		// It's valid for identity attributes to be null, we can just omit it from config
@@ -437,20 +437,20 @@ func appendImportBlockWithIdentity(config teststep.Config, resourceName string, 
 
 		switch v := v.(type) {
 		case bool:
-			configBuilder.WriteString(fmt.Sprintf(`		%q = %t`+"\n", k, v))
+			fmt.Fprintf(&configBuilder, `		%q = %t`+"\n", k, v)
 
 		case []any:
 			var quotedV []string
 			for _, v := range v {
 				quotedV = append(quotedV, fmt.Sprintf(`%q`, v))
 			}
-			configBuilder.WriteString(fmt.Sprintf(`		%q = [%s]`+"\n", k, strings.Join(quotedV, ", ")))
+			fmt.Fprintf(&configBuilder, `		%q = [%s]`+"\n", k, strings.Join(quotedV, ", "))
 
 		case json.Number:
-			configBuilder.WriteString(fmt.Sprintf(`		%q = %s`+"\n", k, v))
+			fmt.Fprintf(&configBuilder, `		%q = %s`+"\n", k, v)
 
 		case string:
-			configBuilder.WriteString(fmt.Sprintf(`		%q = %q`+"\n", k, v))
+			fmt.Fprintf(&configBuilder, `		%q = %q`+"\n", k, v)
 
 		default:
 			panic(fmt.Sprintf("unexpected type %T for identity value %q", v, k))

--- a/helper/resource/teststep_providers.go
+++ b/helper/resource/teststep_providers.go
@@ -71,21 +71,21 @@ func (s TestStep) providerConfig(_ context.Context, skipProviderBlock bool, tfVe
 
 	for name, externalProvider := range s.ExternalProviders {
 		if !skipProviderBlock {
-			providerBlocks.WriteString(fmt.Sprintf("provider %q {}\n", name))
+			fmt.Fprintf(&providerBlocks, "provider %q {}\n", name)
 		}
 
 		if externalProvider.Source == "" && externalProvider.VersionConstraint == "" {
 			continue
 		}
 
-		requiredProviderBlocks.WriteString(fmt.Sprintf("    %s = {\n", name))
+		fmt.Fprintf(&requiredProviderBlocks, "    %s = {\n", name)
 
 		if externalProvider.Source != "" {
-			requiredProviderBlocks.WriteString(fmt.Sprintf("      source = %q\n", externalProvider.Source))
+			fmt.Fprintf(&requiredProviderBlocks, "      source = %q\n", externalProvider.Source)
 		}
 
 		if externalProvider.VersionConstraint != "" {
-			requiredProviderBlocks.WriteString(fmt.Sprintf("      version = %q\n", externalProvider.VersionConstraint))
+			fmt.Fprintf(&requiredProviderBlocks, "      version = %q\n", externalProvider.VersionConstraint)
 		}
 
 		requiredProviderBlocks.WriteString("    }\n")
@@ -154,30 +154,30 @@ func (s TestStep) providerConfigTestCase(_ context.Context, skipProviderBlock bo
 	//      is being used and not the others, but leaving it here just in case
 	//      it does have a special purpose that wasn't being unit tested prior.
 	for name := range providerNames {
-		providerBlocks.WriteString(fmt.Sprintf("provider %q {}\n", name))
+		fmt.Fprintf(&providerBlocks, "provider %q {}\n", name)
 
-		requiredProviderBlocks.WriteString(fmt.Sprintf("    %s = {\n", name))
+		fmt.Fprintf(&requiredProviderBlocks, "    %s = {\n", name)
 
 		requiredProviderBlocks.WriteString("    }\n")
 	}
 
 	for name, externalProvider := range testCase.ExternalProviders {
 		if !skipProviderBlock {
-			providerBlocks.WriteString(fmt.Sprintf("provider %q {}\n", name))
+			fmt.Fprintf(&providerBlocks, "provider %q {}\n", name)
 		}
 
 		if externalProvider.Source == "" && externalProvider.VersionConstraint == "" {
 			continue
 		}
 
-		requiredProviderBlocks.WriteString(fmt.Sprintf("    %s = {\n", name))
+		fmt.Fprintf(&requiredProviderBlocks, "    %s = {\n", name)
 
 		if externalProvider.Source != "" {
-			requiredProviderBlocks.WriteString(fmt.Sprintf("      source = %q\n", externalProvider.Source))
+			fmt.Fprintf(&requiredProviderBlocks, "      source = %q\n", externalProvider.Source)
 		}
 
 		if externalProvider.VersionConstraint != "" {
-			requiredProviderBlocks.WriteString(fmt.Sprintf("      version = %q\n", externalProvider.VersionConstraint))
+			fmt.Fprintf(&requiredProviderBlocks, "      version = %q\n", externalProvider.VersionConstraint)
 		}
 
 		requiredProviderBlocks.WriteString("    }\n")
@@ -250,8 +250,8 @@ func addTerraformBlockSource(name, config string) string {
 
 	var providerBlocks strings.Builder
 
-	providerBlocks.WriteString(fmt.Sprintf("    %s = {\n", name))
-	providerBlocks.WriteString(fmt.Sprintf("      source = %q\n", getProviderAddr(name)))
+	fmt.Fprintf(&providerBlocks, "    %s = {\n", name)
+	fmt.Fprintf(&providerBlocks, "      source = %q\n", getProviderAddr(name))
 	providerBlocks.WriteString("    }\n")
 
 	return providerBlocks.String()

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -803,7 +803,7 @@ func (s *State) String() string {
 			continue
 		}
 
-		buf.WriteString(fmt.Sprintf("module.%s:\n", strings.Join(m.Path[1:], ".")))
+		fmt.Fprintf(&buf, "module.%s:\n", strings.Join(m.Path[1:], "."))
 
 		s := bufio.NewScanner(strings.NewReader(mStr))
 		for s.Scan() {
@@ -812,7 +812,7 @@ func (s *State) String() string {
 				text = "  " + text
 			}
 
-			buf.WriteString(fmt.Sprintf("%s\n", text))
+			fmt.Fprintf(&buf, "%s\n", text)
 		}
 	}
 
@@ -1130,10 +1130,10 @@ func (m *ModuleState) String() string {
 			deposedStr = fmt.Sprintf(" (%d deposed)", len(rs.Deposed))
 		}
 
-		buf.WriteString(fmt.Sprintf("%s:%s%s\n", k, taintStr, deposedStr))
-		buf.WriteString(fmt.Sprintf("  ID = %s\n", id))
+		fmt.Fprintf(&buf, "%s:%s%s\n", k, taintStr, deposedStr)
+		fmt.Fprintf(&buf, "  ID = %s\n", id)
 		if rs.Provider != "" {
-			buf.WriteString(fmt.Sprintf("  provider = %s\n", rs.Provider))
+			fmt.Fprintf(&buf, "  provider = %s\n", rs.Provider)
 		}
 
 		var attributes map[string]string
@@ -1153,7 +1153,7 @@ func (m *ModuleState) String() string {
 
 		for _, ak := range attrKeys {
 			av := attributes[ak]
-			buf.WriteString(fmt.Sprintf("  %s = %s\n", ak, av))
+			fmt.Fprintf(&buf, "  %s = %s\n", ak, av)
 		}
 
 		for idx, t := range rs.Deposed {
@@ -1161,13 +1161,13 @@ func (m *ModuleState) String() string {
 			if t.Tainted {
 				taintStr = " (tainted)"
 			}
-			buf.WriteString(fmt.Sprintf("  Deposed ID %d = %s%s\n", idx+1, t.ID, taintStr))
+			fmt.Fprintf(&buf, "  Deposed ID %d = %s%s\n", idx+1, t.ID, taintStr)
 		}
 
 		if len(rs.Dependencies) > 0 {
 			buf.WriteString("\n  Dependencies:\n")
 			for _, dep := range rs.Dependencies {
-				buf.WriteString(fmt.Sprintf("    %s\n", dep))
+				fmt.Fprintf(&buf, "    %s\n", dep)
 			}
 		}
 	}
@@ -1186,9 +1186,9 @@ func (m *ModuleState) String() string {
 			v := m.Outputs[k]
 			switch vTyped := v.Value.(type) {
 			case string:
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+				fmt.Fprintf(&buf, "%s = %s\n", k, vTyped)
 			case []interface{}:
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+				fmt.Fprintf(&buf, "%s = %s\n", k, vTyped)
 			case map[string]interface{}:
 				var mapKeys []string
 				for key := range vTyped {
@@ -1199,11 +1199,11 @@ func (m *ModuleState) String() string {
 				var mapBuf bytes.Buffer
 				mapBuf.WriteString("{")
 				for _, key := range mapKeys {
-					mapBuf.WriteString(fmt.Sprintf("%s:%s ", key, vTyped[key]))
+					fmt.Fprintf(&mapBuf, "%s:%s ", key, vTyped[key])
 				}
 				mapBuf.WriteString("}")
 
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, mapBuf.String()))
+				fmt.Fprintf(&buf, "%s = %s\n", k, mapBuf.String())
 			}
 		}
 	}
@@ -1438,7 +1438,7 @@ func (s *ResourceState) String() string {
 	defer s.Unlock()
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("Type = %s", s.Type))
+	fmt.Fprintf(&buf, "Type = %s", s.Type)
 	return buf.String()
 }
 
@@ -1748,7 +1748,7 @@ func (s *InstanceState) String() string {
 		return notCreated
 	}
 
-	buf.WriteString(fmt.Sprintf("ID = %s\n", s.ID))
+	fmt.Fprintf(&buf, "ID = %s\n", s.ID)
 
 	attributes := s.Attributes
 	attrKeys := make([]string, 0, len(attributes))
@@ -1763,10 +1763,10 @@ func (s *InstanceState) String() string {
 
 	for _, ak := range attrKeys {
 		av := attributes[ak]
-		buf.WriteString(fmt.Sprintf("%s = %s\n", ak, av))
+		fmt.Fprintf(&buf, "%s = %s\n", ak, av)
 	}
 
-	buf.WriteString(fmt.Sprintf("Tainted = %t\n", s.Tainted))
+	fmt.Fprintf(&buf, "Tainted = %t\n", s.Tainted)
 
 	return buf.String()
 }


### PR DESCRIPTION
## Description

This is a patch release that backports #628 to `v1.14` which allows the Google Terraform provider to upgrade their dependency on plugin-testing to `v1.14`. The alternative of upgrading straight to v1.15 was discussed, but would need a breaking change as new required RPC methods were added in that version. This patch release helps de-risking the upgrade by splitting it into two steps.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
