### PR TITLE
feat: integrate dynamic identity checking

### DIFF
--- a/querycheck/expect_identity_func.go
+++ b/querycheck/expect_identity_func.go
@@ -1,0 +1,93 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package querycheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+)
+
+var _ QueryResultCheck = expectIdentityFunc{}
+
+type expectIdentityFunc struct {
+	listResourceAddress string
+	identityFunc        func() map[string]knownvalue.Check
+}
+
+// Adapted (with updates) from github.com/hashicorp/terraform-plugin-testing/statecheck.ExpectIdentity
+func (e expectIdentityFunc) CheckQuery(_ context.Context, req CheckQueryRequest, resp *CheckQueryResponse) {
+	checks := e.identityFunc()
+
+	for _, res := range req.Query {
+		var errCollection []error
+
+		if e.listResourceAddress != strings.TrimPrefix(res.Address, "list.") {
+			continue
+		}
+
+		if len(res.Identity) != len(checks) {
+			var deltaMsg string
+			if len(res.Identity) > len(checks) {
+				deltaMsg = statecheck.CreateDeltaString(res.Identity, checks, "actual identity has extra attribute(s): ")
+			} else {
+				deltaMsg = statecheck.CreateDeltaString(checks, res.Identity, "actual identity is missing attribute(s): ")
+			}
+
+			resp.Error = fmt.Errorf("%s - Expected %d attribute(s) in the actual identity object, got %d attribute(s): %s", e.listResourceAddress, len(checks), len(res.Identity), deltaMsg)
+			return
+		}
+
+		var keys []string
+
+		for k := range checks {
+			keys = append(keys, k)
+		}
+
+		slices.Sort(keys)
+
+		for _, k := range keys {
+			actualIdentityVal, ok := res.Identity[k]
+
+			if !ok {
+				resp.Error = fmt.Errorf("%s - missing attribute %q in actual identity object", e.listResourceAddress, k)
+				return
+			}
+
+			if err := checks[k].CheckValue(actualIdentityVal); err != nil {
+				errCollection = append(errCollection, fmt.Errorf("%s - %q identity attribute: %w", e.listResourceAddress, k, err))
+			}
+		}
+
+		if errCollection == nil {
+			return
+		}
+	}
+
+	var errCollection []error
+	errCollection = append(errCollection, fmt.Errorf("an identity with the following attributes was not found"))
+
+	// wrap errors for each check
+	for attr, check := range checks {
+		errCollection = append(errCollection, fmt.Errorf("attribute %q: %s", attr, check))
+	}
+	errCollection = append(errCollection, fmt.Errorf("address: %s\n", e.listResourceAddress))
+	resp.Error = errors.Join(errCollection...)
+}
+
+// ExpectIdentityFunc returns a query check that asserts that the given list resource contains a resource with an identity matching
+// the identity checks returned by the identityFunc.
+//
+// This query check can only be used with managed resources that support resource identity and query. Query is only supported in Terraform v1.14+
+func ExpectIdentityFunc(resourceAddress string, identityFunc func() map[string]knownvalue.Check) QueryResultCheck {
+	return expectIdentityFunc{
+		listResourceAddress: resourceAddress,
+		identityFunc:        identityFunc,
+	}
+}

--- a/querycheck/expect_no_identity_func.go
+++ b/querycheck/expect_no_identity_func.go
@@ -1,0 +1,89 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package querycheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+)
+
+var _ QueryResultCheck = expectNoIdentityFunc{}
+
+type expectNoIdentityFunc struct {
+	listResourceAddress string
+	identityFunc        func() map[string]knownvalue.Check
+}
+
+// Adapted (with updates) from github.com/hashicorp/terraform-plugin-testing/statecheck.ExpectNoIdentity
+func (e expectNoIdentityFunc) CheckQuery(_ context.Context, req CheckQueryRequest, resp *CheckQueryResponse) {
+	checks := e.identityFunc()
+
+	for _, res := range req.Query {
+		var errCollection []error
+
+		if e.listResourceAddress != strings.TrimPrefix(res.Address, "list.") {
+			continue
+		}
+
+		if len(res.Identity) != len(checks) {
+			var deltaMsg string
+			if len(res.Identity) > len(checks) {
+				deltaMsg = statecheck.CreateDeltaString(res.Identity, checks, "actual identity has extra attribute(s): ")
+			} else {
+				deltaMsg = statecheck.CreateDeltaString(checks, res.Identity, "actual identity is missing attribute(s): ")
+			}
+
+			resp.Error = fmt.Errorf("%s - Expected %d attribute(s) in the actual identity object, got %d attribute(s): %s", e.listResourceAddress, len(checks), len(res.Identity), deltaMsg)
+			return
+		}
+
+		var keys []string
+
+		for k := range checks {
+			keys = append(keys, k)
+		}
+
+		slices.Sort(keys)
+
+		for _, k := range keys {
+			actualIdentityVal, ok := res.Identity[k]
+
+			if !ok {
+				resp.Error = fmt.Errorf("%s - missing attribute %q in actual identity object", e.listResourceAddress, k)
+				return
+			}
+
+			if err := checks[k].CheckValue(actualIdentityVal); err != nil {
+				errCollection = append(errCollection, fmt.Errorf("%s - %q identity attribute: %w", e.listResourceAddress, k, err))
+			}
+		}
+
+		if errCollection == nil {
+			errs := []error{fmt.Errorf("an unexpected identity matching the given attributes was found")}
+			// wrap errors for each check
+			for attr, check := range checks {
+				errs = append(errs, fmt.Errorf("attribute %q: %s", attr, check))
+			}
+			errs = append(errs, fmt.Errorf("address: %s\n", e.listResourceAddress))
+			resp.Error = errors.Join(errs...)
+		}
+	}
+}
+
+// ExpectNoIdentityFunc returns a query check that asserts that the given list resource does not contain a resource with an identity matching
+// the identity checks returned by the identityFunc.
+//
+// This query check can only be used with managed resources that support resource identity and query. Query is only supported in Terraform v1.14+
+func ExpectNoIdentityFunc(resourceAddress string, identityFunc func() map[string]knownvalue.Check) QueryResultCheck {
+	return expectNoIdentityFunc{
+		listResourceAddress: resourceAddress,
+		identityFunc:        identityFunc,
+	}
+}

--- a/querycheck/expect_no_resource_object.go
+++ b/querycheck/expect_no_resource_object.go
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package querycheck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
+)
+
+var _ QueryResultCheck = expectNoResourceObject{}
+
+type expectNoResourceObject struct {
+	listResourceAddress string
+	filter              queryfilter.QueryFilter
+}
+
+func (e expectNoResourceObject) QueryFilters(ctx context.Context) []queryfilter.QueryFilter {
+	if e.filter == nil {
+		return []queryfilter.QueryFilter{}
+	}
+
+	return []queryfilter.QueryFilter{
+		e.filter,
+	}
+}
+
+// Adapted (with updates) from github.com/hashicorp/terraform-plugin-testing/statecheck.ExpectIdentity
+func (e expectNoResourceObject) CheckQuery(_ context.Context, req CheckQueryRequest, resp *CheckQueryResponse) {
+	var listRes []tfjson.ListResourceFoundData
+	for _, res := range req.Query {
+		if e.listResourceAddress == strings.TrimPrefix(res.Address, "list.") {
+			listRes = append(listRes, res)
+		}
+	}
+
+	if len(listRes) == 0 {
+		resp.Error = fmt.Errorf("%s - no query results found after filtering", e.listResourceAddress)
+		return
+	}
+
+	if len(listRes) > 1 {
+		resp.Error = fmt.Errorf("%s - more than 1 query result found after filtering", e.listResourceAddress)
+		return
+	}
+
+	res := listRes[0]
+
+	if res.ResourceObject != nil {
+		resp.Error = fmt.Errorf("%s - Expected no resource data, but was present!", e.listResourceAddress)
+		return
+	}
+}
+
+// ExpectNoResourceObjet returns a query check that asserts that the given list resource contains no resource data.
+//
+// This query check can only be used with managed resources that support resource identity and query. Query is only supported in Terraform v1.14+
+func ExpectNoResourceObject(resourceAddress string, filter queryfilter.QueryFilter) QueryResultCheck {
+	return expectNoResourceObject{
+		listResourceAddress: resourceAddress,
+		filter:              filter,
+	}
+}

--- a/querycheck/known_value_check.go
+++ b/querycheck/known_value_check.go
@@ -1,0 +1,16 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package querycheck
+
+import (
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func NewKnownValueCheck(path tfjsonpath.Path, check knownvalue.Check) KnownValueCheck {
+	return KnownValueCheck{
+		Path:       path,
+		KnownValue: check,
+	}
+}

--- a/querycheck/queryfilter/by_resource_identity_func.go
+++ b/querycheck/queryfilter/by_resource_identity_func.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package queryfilter
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+)
+
+type filterByResourceIdentityFunc struct {
+	identityFunc func() map[string]knownvalue.Check
+}
+
+func (f filterByResourceIdentityFunc) Filter(ctx context.Context, req FilterQueryRequest, resp *FilterQueryResponse) {
+	inner := ByResourceIdentity(f.identityFunc())
+	inner.Filter(ctx, req, resp)
+}
+
+// ByResourceIdentityFunc returns a query filter that only includes query items that match
+// the given resource identity.
+//
+// Errors thrown by the given known value checks are only used to filter out non-matching query
+// items and are otherwise ignored.
+func ByResourceIdentityFunc(identityFunc func() map[string]knownvalue.Check) QueryFilter {
+	return filterByResourceIdentityFunc{
+		identityFunc: identityFunc,
+	}
+}

--- a/statecheck/base.go
+++ b/statecheck/base.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package statecheck
+
+import (
+	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+type Base struct {
+	resourceAddress string
+}
+
+func NewBase(resourceAddress string) Base {
+	return Base{
+		resourceAddress: resourceAddress,
+	}
+}
+
+func (b Base) ResourceFromState(req CheckStateRequest, resp *CheckStateResponse) (*tfjson.StateResource, bool) {
+	var resource *tfjson.StateResource
+
+	if req.State == nil {
+		resp.Error = fmt.Errorf("state is nil")
+
+		return nil, false
+	}
+
+	if req.State.Values == nil {
+		resp.Error = fmt.Errorf("state does not contain any state values")
+
+		return nil, false
+	}
+
+	if req.State.Values.RootModule == nil {
+		resp.Error = fmt.Errorf("state does not contain a root module")
+
+		return nil, false
+	}
+
+	for _, r := range req.State.Values.RootModule.Resources {
+		if b.resourceAddress == r.Address {
+			resource = r
+
+			break
+		}
+	}
+
+	if resource == nil {
+		resp.Error = fmt.Errorf("%s - Resource not found in state", b.resourceAddress)
+
+		return nil, false
+	}
+
+	return resource, true
+}
+
+func (b Base) ResourceAddress() string {
+	return b.resourceAddress
+}

--- a/statecheck/identity.go
+++ b/statecheck/identity.go
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package statecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+)
+
+type identity struct {
+	resourceAddress string
+	values          map[string]any
+}
+
+func Identity() identity {
+	return identity{}
+}
+
+// GetIdentity sets the resource address to check and stores the identity values.
+// Calls to GetIdentity occur before any TestStep is run.
+func (v *identity) GetIdentity(resourceAddress string) StateCheck {
+	v.resourceAddress = resourceAddress
+
+	return newIdentityStateChecker(v)
+}
+
+type identityStateChecker struct {
+	base     Base
+	identity *identity
+}
+
+func newIdentityStateChecker(identity *identity) identityStateChecker {
+	return identityStateChecker{
+		base:     NewBase(identity.resourceAddress),
+		identity: identity,
+	}
+}
+
+func (vc identityStateChecker) CheckState(ctx context.Context, request CheckStateRequest, response *CheckStateResponse) {
+	resource, ok := vc.base.ResourceFromState(request, response)
+	if !ok {
+		return
+	}
+
+	if resource.IdentitySchemaVersion == nil || len(resource.IdentityValues) == 0 {
+		response.Error = fmt.Errorf("%s - Identity not found in state. Either the resource does not support identity or the Terraform version running the test does not support identity. (must be v1.12+)", vc.base.resourceAddress)
+
+		return
+	}
+
+	vc.identity.values = maps.Collect(maps.All(resource.IdentityValues))
+}
+
+// Checks returns a function that provides the identity values as knownvalue.Checks.
+// Calls to Checks occur before any TestStep is run.
+func (v *identity) Checks() func() map[string]knownvalue.Check {
+	return func() map[string]knownvalue.Check {
+		checks := make(map[string]knownvalue.Check, len(v.values))
+
+		for k, val := range v.values {
+			// add check for optional identities that may be nil
+			if val == nil {
+				checks[k] = knownvalue.Null()
+			} else {
+				switch v := val.(type) {
+				case string:
+					checks[k] = knownvalue.StringExact(v)
+				case json.Number:
+					if i, err := v.Int64(); err == nil {
+						checks[k] = knownvalue.Int64Exact(i)
+					} else {
+						checks[k] = knownvalue.StringExact(v.String())
+					}
+				default:
+					checks[k] = knownvalue.StringExact(fmt.Sprintf("%v", val))
+				}
+			}
+		}
+
+		return checks
+	}
+}


### PR DESCRIPTION
This PR contains code from this third-party repository: https://github.com/hashicorp/terraform-provider-aws

## Description

While implementing Lists and testing for specific Identities returned, I stumbled upon these useful wrapper functions in  [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws):

- [querychecks](https://github.com/hashicorp/terraform-provider-aws/tree/main/internal/acctest/querycheck)
- [queryfilters](https://github.com/hashicorp/terraform-provider-aws/tree/main/internal/acctest/queryfilter)
- [identity statechecks](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/acctest/statecheck/identity.go) (and [base](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/acctest/statecheck/base.go))

Since these wrappers are provider agnostic, it would seem appropriate for them to be integrated directly in `terraform-plugin-testing` (instead of multiplying provider-level implementations). 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

