### PR TITLE
helper/resource: include step number in import state verification failures

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260724-123249.yaml
+++ b/.changes/unreleased/BUG FIXES-20260724-123249.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'helper/resource: Include the test step number in import state verification failure messages.'
+time: 2026-07-24T12:32:49.356719+02:00
+custom:
+    Issue: "525"

--- a/helper/resource/importstate/import_command_with_id_error_test.go
+++ b/helper/resource/importstate/import_command_with_id_error_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package importstate_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	testinginterface "github.com/mitchellh/go-testing-interface"
+
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/internal/plugintest"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/providerserver"
+	"github.com/hashicorp/terraform-plugin-testing/internal/testing/testsdk/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+type importStateVerifyRecordingT struct {
+	testinginterface.RuntimeT
+	fatalfMessages []string
+}
+
+func (t *importStateVerifyRecordingT) Fatalf(format string, args ...interface{}) {
+	t.fatalfMessages = append(t.fatalfMessages, fmt.Sprintf(format, args...))
+	t.RuntimeT.FailNow()
+}
+
+func TestImportCommand_ImportStateVerifyFailureIncludesStepNumber(t *testing.T) { //nolint:paralleltest
+	testT := &importStateVerifyRecordingT{}
+
+	plugintest.TestExpectTFatal(t, func() {
+		r.UnitTest(testT, r.TestCase{
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBelow(tfversion.Version1_0_0), // ProtoV6ProviderFactories
+			},
+			ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+				"examplecloud": providerserver.NewProviderServer(testprovider.Provider{
+					Resources: map[string]testprovider.Resource{
+						"examplecloud_thing": {
+							CreateResponse: &resource.CreateResponse{
+								NewState: tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"id": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"id": tftypes.NewValue(tftypes.String, "resource-test"),
+									},
+								),
+							},
+							ImportStateResponse: &resource.ImportStateResponse{
+								State: tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"id": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"id": tftypes.NewValue(tftypes.String, "imported-resource-test"),
+									},
+								),
+							},
+							SchemaResponse: &resource.SchemaResponse{
+								Schema: &tfprotov6.Schema{
+									Block: &tfprotov6.SchemaBlock{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "id",
+												Type:     tftypes.String,
+												Computed: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			Steps: []r.TestStep{
+				{
+					Config: `resource "examplecloud_thing" "test" {}`,
+				},
+				{
+					ResourceName:      "examplecloud_thing.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	expected := "Step 2/2 error running import: Failed state verification, resource with ID imported-resource-test not found"
+	actual := strings.Join(testT.fatalfMessages, "\n")
+
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected fatal output to contain %q, got:\n%s", expected, actual)
+	}
+}

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -348,9 +348,7 @@ func testImportCommand(ctx context.Context, t testing.T, workingDir *plugintest.
 				}
 			}
 			if oldR == nil || oldR.Primary == nil {
-				t.Fatalf(
-					"Failed state verification, resource with ID %s not found",
-					rIdentifier)
+				return fmt.Errorf("Failed state verification, resource with ID %s not found", rIdentifier)
 			}
 
 			// don't add empty flatmapped containers, so we can more easily


### PR DESCRIPTION
## Related Issue

Fixes #525

## Description

When import state verification cannot find the imported resource ID in the prior state, the verification currently calls `t.Fatalf` directly. This prevents the outer test step runner from adding the step number to the failure message.

This change returns the verification error instead, allowing the existing import step error handling to report the failure with its step number.

A regression test was added to verify that the final error includes `Step 2/2`, along with a Changie entry for the bug fix.

## Testing

The import state test package passes with both Go versions used by the repository CI matrix:

- `GOTOOLCHAIN=go1.25.12 go test ./helper/resource/importstate -count=1`
- `GOTOOLCHAIN=go1.26.5 go test ./helper/resource/importstate -count=1`

Tested with:

- Windows 11 Pro 10.0.26200
- Terraform 1.15.8
- Go 1.25.12 and 1.26.5
- Git 2.54.0.windows.1

`go test ./... -count=1` also encounters pre-existing Windows-specific failures in `config`, `helper/resource`, and `internal/teststep`. The same failures were reproduced on an unmodified `upstream/main` worktree.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.
