### PR TITLE
internal/plugintest: fix CopyDir paths on Windows

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260724-142353.yaml
+++ b/.changes/unreleased/BUG FIXES-20260724-142353.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'helper/resource: Fix persisted working directory copying on Windows.'
+time: 2026-07-24T14:23:53.759+02:00
+custom:
+    Issue: "672"

--- a/internal/plugintest/util.go
+++ b/internal/plugintest/util.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -119,8 +118,8 @@ func CopyDir(src, dest, baseDirName string) error {
 	}
 
 	for _, dirEntry := range dirEntries {
-		srcFilepath := path.Join(src, dirEntry.Name())
-		destFilepath := path.Join(dest, dirEntry.Name())
+		srcFilepath := filepath.Join(src, dirEntry.Name())
+		destFilepath := filepath.Join(dest, dirEntry.Name())
 
 		if !strings.Contains(srcFilepath, baseDirName) {
 			continue

--- a/internal/plugintest/util_test.go
+++ b/internal/plugintest/util_test.go
@@ -123,3 +123,29 @@ func dirEntryComparer(t *testing.T) cmp.Option {
 		return true
 	})
 }
+
+func TestCopyDirWithBaseDirName(t *testing.T) {
+	t.Parallel()
+
+	srcDir := t.TempDir()
+	baseDir := filepath.Join(srcDir, "work")
+
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("cannot create base directory: %s", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(baseDir, "src.txt"), []byte("test"), 0o600); err != nil {
+		t.Fatalf("cannot create source file: %s", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "dest")
+	baseDirName := baseDir[len(srcDir):]
+
+	if err := CopyDir(srcDir, destDir, baseDirName); err != nil {
+		t.Fatalf("cannot copy directory: %s", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "work", "src.txt")); err != nil {
+		t.Fatalf("cannot stat copied source file: %s", err)
+	}
+}


### PR DESCRIPTION
## Related Issue

Fixes #672

## Description

`CopyDir` currently builds filesystem paths using `path.Join`, which always uses forward slashes.

When `copyWorkingDir` passes a `baseDirName` derived from native Windows paths, the subsequent substring check can compare paths containing different separators. This causes matching entries to be skipped without returning an error, leaving persisted `step_N` directories without the expected working directory contents.

This change uses `filepath.Join` for filesystem paths so that the generated paths use the native platform separator.

A regression test was added using a non-empty `baseDirName` to verify that the expected nested file is copied successfully.

## Testing

The affected package and the existing persisted working directory tests pass with both Go versions used by the repository CI matrix:

- `GOTOOLCHAIN=go1.25.12 go test ./internal/plugintest -count=1`
- `GOTOOLCHAIN=go1.25.12 go test ./helper/resource -run PersistWorkingDir -count=1`
- `GOTOOLCHAIN=go1.26.5 go test ./internal/plugintest -count=1`
- `GOTOOLCHAIN=go1.26.5 go test ./helper/resource -run PersistWorkingDir -count=1`

The new regression test was also verified to fail before the production change and pass afterward.

Tested with:

- Windows 11 Pro 10.0.26200
- Terraform 1.15.8
- Go 1.25.12 and 1.26.5
- Git 2.54.0.windows.1

Other unrelated Windows-specific unit test portability failures are tracked separately in #673.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.